### PR TITLE
Enable using flags for default actions

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -9,11 +9,22 @@ import (
 )
 
 func CatalogCommand() cli.Command {
+	catalogLsFlags := []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet,q",
+			Usage: "Only display IDs",
+		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
+		},
+	}
+
 	return cli.Command{
 		Name:   "catalog",
 		Usage:  "Operations with catalogs",
 		Action: defaultAction(catalogLs),
-		Flags:  []cli.Flag{},
+		Flags:  catalogLsFlags,
 		Subcommands: []cli.Command{
 			cli.Command{
 				Name:        "ls",
@@ -21,16 +32,7 @@ func CatalogCommand() cli.Command {
 				Description: "\nList all catalog templates in the current $RANCHER_ENVIRONMENT. Use `--env <envID>` or `--env <envName>` to select a different environment.\n\nExample:\n\t$ rancher --env k8slab catalog ls\n",
 				ArgsUsage:   "None",
 				Action:      catalogLs,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "quiet,q",
-						Usage: "Only display IDs",
-					},
-					cli.StringFlag{
-						Name:  "format",
-						Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
-					},
-				},
+				Flags:       catalogLsFlags,
 			},
 			/*	cli.Command{
 					Name:   "install",

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -9,11 +9,24 @@ import (
 )
 
 func EnvCommand() cli.Command {
+	envLsFlags := []cli.Flag{
+		listAllFlag(),
+		cli.BoolFlag{
+			Name:  "quiet,q",
+			Usage: "Only display IDs",
+		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
+		},
+	}
+
 	return cli.Command{
 		Name:      "environment",
 		ShortName: "env",
 		Usage:     "Interact with environments",
 		Action:    defaultAction(envLs),
+		Flags:     envLsFlags,
 		Subcommands: []cli.Command{
 			cli.Command{
 				Name:        "ls",
@@ -21,17 +34,7 @@ func EnvCommand() cli.Command {
 				Description: "\nWith an account API key, all environments in Rancher will be listed. If you are using an environment API key, it will only list the environment of the API key. \n\nExample:\n\t$ rancher env ls\n",
 				ArgsUsage:   "None",
 				Action:      envLs,
-				Flags: []cli.Flag{
-					listAllFlag(),
-					cli.BoolFlag{
-						Name:  "quiet,q",
-						Usage: "Only display IDs",
-					},
-					cli.StringFlag{
-						Name:  "format",
-						Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
-					},
-				},
+				Flags:       envLsFlags,
 			},
 			cli.Command{
 				Name:        "create",

--- a/cmd/host.go
+++ b/cmd/host.go
@@ -6,11 +6,23 @@ import (
 )
 
 func HostCommand() cli.Command {
+	hostLsFlags := []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet,q",
+			Usage: "Only display IDs",
+		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
+		},
+	}
+
 	return cli.Command{
 		Name:      "hosts",
 		ShortName: "host",
 		Usage:     "Operations on hosts",
 		Action:    defaultAction(hostLs),
+		Flags:     hostLsFlags,
 		Subcommands: []cli.Command{
 			cli.Command{
 				Name:        "ls",
@@ -18,16 +30,7 @@ func HostCommand() cli.Command {
 				Description: "\nLists all hosts in the current $RANCHER_ENVIRONMENT. Use `--env <envID>` or `--env <envName>` to select a different environment.\n\nExample:\n\t$ rancher hosts ls\n\t$ rancher --env 1a5 hosts ls\n",
 				ArgsUsage:   "None",
 				Action:      hostLs,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "quiet,q",
-						Usage: "Only display IDs",
-					},
-					cli.StringFlag{
-						Name:  "format",
-						Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
-					},
-				},
+				Flags:       hostLsFlags,
 			},
 			cli.Command{
 				Name:            "create",

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -8,11 +8,23 @@ import (
 )
 
 func StackCommand() cli.Command {
+	stackLsFlags := []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet,q",
+			Usage: "Only display IDs",
+		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
+		},
+	}
+
 	return cli.Command{
 		Name:      "stacks",
 		ShortName: "stack",
 		Usage:     "Operations on stacks",
 		Action:    defaultAction(stackLs),
+		Flags:     stackLsFlags,
 		Subcommands: []cli.Command{
 			cli.Command{
 				Name:        "ls",
@@ -20,16 +32,7 @@ func StackCommand() cli.Command {
 				Description: "\nLists all stacks in the current $RANCHER_ENVIRONMENT. Use `--env <envID>` or `--env <envName>` to select a different environment.\n\nExample:\n\t$ rancher stacks ls\n\t$ rancher --env 1a5 stacks ls\n",
 				ArgsUsage:   "None",
 				Action:      stackLs,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "quiet,q",
-						Usage: "Only display IDs",
-					},
-					cli.StringFlag{
-						Name:  "format",
-						Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
-					},
-				},
+				Flags:       stackLsFlags,
 			},
 		},
 	}

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -10,36 +10,29 @@ import (
 )
 
 func VolumeCommand() cli.Command {
+	volumeLsFlags := []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet,q",
+			Usage: "Only display IDs",
+		},
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
+		},
+	}
+
 	return cli.Command{
 		Name:      "volumes",
 		ShortName: "volume",
 		Usage:     "Operations on volumes",
 		Action:    defaultAction(volumeLs),
-		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  "quiet,q",
-				Usage: "Only display IDs",
-			},
-			cli.StringFlag{
-				Name:  "format",
-				Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
-			},
-		},
+		Flags:     volumeLsFlags,
 		Subcommands: []cli.Command{
 			cli.Command{
 				Name:   "ls",
 				Usage:  "List volumes",
 				Action: volumeLs,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "quiet,q",
-						Usage: "Only display IDs",
-					},
-					cli.StringFlag{
-						Name:  "format",
-						Usage: "'json' or Custom format: {{.Id}} {{.Name}}",
-					},
-				},
+				Flags:  volumeLsFlags,
 			},
 			cli.Command{
 				Name:   "rm",


### PR DESCRIPTION
So you can do cool stuff like `rancher deactivate $(rancher hosts -q)` without explicitly specifying the `ls` command.