### PR TITLE
Added basic HTTP auth to template details request

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -310,8 +310,8 @@ func getTemplateVersion(ctx *cli.Context, cc *catalog.RancherClient, template ca
 	config, err := lookupConfig(ctx)
 	if err != nil {
 		return templateVersion, err
-	}	
-	
+	}
+
 	if version == "" {
 		version = template.DefaultVersion
 	}

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -307,7 +307,11 @@ func toString(s interface{}) string {
 
 func getTemplateVersion(ctx *cli.Context, cc *catalog.RancherClient, template catalog.Template, name, version string) (catalog.TemplateVersion, error) {
 	templateVersion := catalog.TemplateVersion{}
-
+	config, err := lookupConfig(ctx)
+	if err != nil {
+		return templateVersion, err
+	}	
+	
 	if version == "" {
 		version = template.DefaultVersion
 	}
@@ -318,7 +322,10 @@ func getTemplateVersion(ctx *cli.Context, cc *catalog.RancherClient, template ca
 		return templateVersion, fmt.Errorf("Failed to find the version %s for template %s", version, name)
 	}
 
-	resp, err := http.Get(fmt.Sprint(link))
+	client := &http.Client{}
+    req, err := http.NewRequest("GET", fmt.Sprint(link), nil)
+    req.SetBasicAuth(config.AccessKey, config.SecretKey)
+    resp, err := client.Do(req)
 	if err != nil {
 		return templateVersion, err
 	}

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -323,9 +323,9 @@ func getTemplateVersion(ctx *cli.Context, cc *catalog.RancherClient, template ca
 	}
 
 	client := &http.Client{}
-    req, err := http.NewRequest("GET", fmt.Sprint(link), nil)
-    req.SetBasicAuth(config.AccessKey, config.SecretKey)
-    resp, err := client.Do(req)
+	req, err := http.NewRequest("GET", fmt.Sprint(link), nil)
+	req.SetBasicAuth(config.AccessKey, config.SecretKey)
+	resp, err := client.Do(req)
 	if err != nil {
 		return templateVersion, err
 	}


### PR DESCRIPTION
When installing a stack from a catalog template, a unauthenticated request to the catalog URL was made. This fixes this by adding basic HTTP auth headers to the request using the configured key and secret.

This fixes https://github.com/rancher/rancher/issues/7182