### PR TITLE
Fix binaries path build/bin -> bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ INFO[0102] Saving config to /Users/<username>/.rancher/cli.json
 
 ## Building
 
-The binaries will be located in `/build/bin`.
+The binaries will be located in `/bin`.
 
 ### Linux binary
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine
-COPY rancher /usr/bin/
+COPY bin/rancher /usr/bin/
 ENTRYPOINT ["rancher"]


### PR DESCRIPTION
Hello!

I were setting up creation of docker image to use in our build system. Found some minor mistakes:
1. readme says binaries will be located in **build/bin**, but they are actually appear in bin folder
3. **build/bin** stays empty
4. **dist** folder also have some empty folders after build
5. added **bin/** path to Dockerfile in package 

There are still some issues I am ready to fix after discussion, before pushing this changes:
1. why we have empty **build/bin** and **dist**? Should they be removed?
2. **.dockerignore** prevents straightforward using of **package/Dockerfile** as it forbids copying of **bin/rancher**. Do you know elegant way to bypass this when using something like `docker build -f package/Dockerfile --pull -t rancher_cli .` ? Now I am simply removing .dockerignore in CI before build.