### PR TITLE
Let users query all environments

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -111,8 +111,12 @@ func GetEnvironment(def string, c *client.RancherClient) (*client.Project, error
 		for _, p := range resp.Data {
 			names = append(names, fmt.Sprintf("%s(%s)", p.Name, p.Id))
 		}
+		names = append(names, "ALL")
 
 		idx := selectFromList("Environments:", names)
+		if idx == len(resp.Data) {
+			return nil, nil
+		}
 		return &resp.Data[idx], nil
 	}
 
@@ -120,6 +124,9 @@ func GetEnvironment(def string, c *client.RancherClient) (*client.Project, error
 }
 
 func LookupEnvironment(c *client.RancherClient, name string) (*client.Project, error) {
+	if name == "ALL" {
+		return nil, nil
+	}
 	env, err := Lookup(c, name, "account")
 	if err != nil {
 		return nil, err

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -55,14 +55,20 @@ func (c Config) EnvironmentURL() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		projectID = project.Id
+		if project != nil {
+			projectID = project.Id
+		}
 	}
 
 	url, err := baseURL(c.URL)
 	if err != nil {
 		return "", err
 	}
-	url = url + "/v2-beta/projects/" + projectID + "/schemas"
+	if projectID == "" || projectID == "ALL" {
+		url = url + "/v2-beta/schemas"
+	} else {
+		url = url + "/v2-beta/projects/" + projectID + "/schemas"
+	}
 	return url, nil
 }
 


### PR DESCRIPTION
This is probably not the greatest implementation, but at least it'll get the discussion going.

The goal is here to be able to query all environments, to e.g. find in which environment an host is located. With this patch, you can use:

```shell
$ rancher --env ALL host   --format '{{.ID}} {{.Host.Hostname}} {{.Host.AccountId}}'
```

to retrieve that info. It also allows to set `environment` to `"ALL"` in the json configuration file for an account API key.

The choice for "ALL" instead of an empty string is because the current behavior with an empty environment is to list all existing environments.

