### PR TITLE
Show the state of containers when making a selection

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -134,7 +134,7 @@ func getHostnameAndContainerIDFromList(c *client.RancherClient, containers clien
 		} else {
 			name = container.Name
 		}
-		names = append(names, fmt.Sprintf("%s (%s)", name, container.PrimaryIpAddress))
+		names = append(names, fmt.Sprintf("%s (%s, %s)", name, container.PrimaryIpAddress, container.State))
 	}
 
 	index := selectFromList("Containers:", names)


### PR DESCRIPTION
This affects the `rancher exec` command.

Showing the current state of containers in the selection dialog improves the workflow of the `rancher exec` command.

### Example

```
rancher exec site -ti /bin/bash
Containers:
[1] service-site-1 (10.42.80.152, stopped)
[2] service-site-1 (10.42.157.249, running)
Select: 
```