### PR TITLE
Use  /project API to find environment instead of /account API

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -120,12 +120,9 @@ func GetEnvironment(def string, c *client.RancherClient) (*client.Project, error
 }
 
 func LookupEnvironment(c *client.RancherClient, name string) (*client.Project, error) {
-	env, err := Lookup(c, name, "account")
+	env, err := Lookup(c, name, "project")
 	if err != nil {
 		return nil, err
-	}
-	if env.Type != "project" {
-		return nil, fmt.Errorf("Failed to find environment: %s", name)
 	}
 	return c.Project.ById(env.Id)
 }
@@ -207,12 +204,18 @@ func Lookup(c *client.RancherClient, name string, types ...string) (*client.Reso
 		}
 
 		var collection client.ResourceCollection
-		if err := c.List(schemaType, &client.ListOpts{
+
+		listOpts := &client.ListOpts{
 			Filters: map[string]interface{}{
 				"name":         name,
 				"removed_null": 1,
 			},
-		}, &collection); err != nil {
+		}
+		if schemaType == "project" {
+			listOpts.Filters["all"] = true
+		}
+
+		if err := c.List(schemaType, listOpts, &collection); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
If a non-admin user calls the /account API, it will not return any projects. So rancher cli can not find the environment by environment name. If we use the /project API, it will return all the environments the user has. But it will only return parts of environments for an admin user if the request doesn't have the parameter all=true. So we have to add this query parameter in this case.

https://github.com/rancher/rancher/issues/9988