### PR TITLE
Improve shebang

### DIFF
--- a/contrib/rancher
+++ b/contrib/rancher
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 [[ -d ~/.rancher ]] || mkdir -p  ~/.rancher
 [[ -d ~/.ssh ]] || mkdir -p  ~/.ssh


### PR DESCRIPTION
It is generally better to use `#!/usr/bin/env bash`  than `#!/bin/bash`. `/bin/bash` isn't available everywhere.