### PR TITLE
Feat: Deploy catalog packages that uses go templating at docker compose

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -272,9 +272,15 @@ func catalogInstall(ctx *cli.Context) error {
 	id := ""
 	switch proj.Orchestration {
 	case "cattle":
+		var composeFile string
+		if templateVersion.Files["docker-compose.yml"] == "" {
+			composeFile = toString(templateVersion.Files["docker-compose.yml.tpl"])
+		} else {
+			composeFile = toString(templateVersion.Files["docker-compose.yml"])
+		}
 		stack, err := c.Stack.Create(&client.Stack{
 			Name:           stackName,
-			DockerCompose:  toString(templateVersion.Files["docker-compose.yml"]),
+			DockerCompose:  composeFile,
 			RancherCompose: toString(templateVersion.Files["rancher-compose.yml"]),
 			Environment:    answers,
 			ExternalId:     externalID,


### PR DESCRIPTION
Catalog packages that uses go templating, docker-compose.yml.tpl, are not deployed correctly from the rancher cli. This PR solves it.  