### PR TITLE
Add option flags for project create and ps

### DIFF
--- a/cliclient/cliclient.go
+++ b/cliclient/cliclient.go
@@ -47,12 +47,11 @@ func NewMasterClient(config *config.ServerConfig) (*MasterClient, error) {
 	mc.ClusterClient = cClient
 
 	// Setup the project client
-	options.URL = baseURL + "/projects/" + config.Project
-	pClient, err := projectClient.NewClient(options)
+	pClient, err := NewProjectClient(config)
 	if err != nil {
 		return nil, err
 	}
-	mc.ProjectClient = pClient
+	mc.ProjectClient = pClient.ProjectClient
 
 	return mc, nil
 }
@@ -71,6 +70,23 @@ func NewManagementClient(config *config.ServerConfig) (*MasterClient, error) {
 		return nil, err
 	}
 	mc.ManagementClient = mClient
+	return mc, nil
+}
+
+func NewProjectClient(config *config.ServerConfig) (*MasterClient, error) {
+	mc := &MasterClient{
+		UserConfig: config,
+	}
+
+	options := createClientOpts(config)
+	options.URL = options.URL + "/projects/" + config.Project
+
+	// Setup the project client
+	pc, err := projectClient.NewClient(options)
+	if err != nil {
+		return nil, err
+	}
+	mc.ProjectClient = pc
 	return mc, nil
 }
 

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -33,6 +33,12 @@ func ProjectCommand() cli.Command {
 				Description: "\nCreates a project in the current cluster.",
 				ArgsUsage:   "[NEWPROJECTNAME...]",
 				Action:      projectCreate,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "cluster",
+						Usage: "Cluster ID to create the project in",
+					},
+				},
 			},
 			{
 				Name:      "delete",
@@ -84,9 +90,18 @@ func projectCreate(ctx *cli.Context) error {
 		return err
 	}
 
+	clusterID := c.UserConfig.FocusedCluster()
+	if ctx.String("cluster") != "" {
+		cluster, err := getClusterByID(c, ctx.String("cluster"))
+		if nil != err {
+			return err
+		}
+		clusterID = cluster.ID
+	}
+
 	newProj := &managementClient.Project{
 		Name:      ctx.Args().First(),
-		ClusterId: c.UserConfig.FocusedCluster(),
+		ClusterId: clusterID,
 	}
 
 	_, err = c.ManagementClient.Project.Create(newProj)


### PR DESCRIPTION
Add flag `--cluster` for `project create` allowing specifying of cluster to create the project in outside of the currently set context.

Add `--project` flag for `ps` to specify which project `ps` will show workloads for. 

Issue https://github.com/rancher/rancher/issues/11469