### PR TITLE
cliclient fixes (master)

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -46,8 +46,8 @@ func loadAndVerifyCert(path string) (string, error) {
 		return "", errors.New("No cert was found")
 	}
 
-	parsedCert, err := x509.ParseCertificate(block.Bytes)
-	if !parsedCert.IsCA {
+	_, err = x509.ParseCertificate(block.Bytes)
+	if err != nil {
 		return "", errors.New("CACerts is not valid")
 	}
 	return string(caCert), nil


### PR DESCRIPTION
This PR contains modifications at:
- `cliclient/cliclient.go`: 
  - [FIX] added `TokenKey` at `createClientOpts` function. 
  - created `MasterClient` functions to cleaner code.
  - added `CheckProject` function to check correct project string format.
- `cmd/common.go`: 
  - [FIX] replaced `parsedCert.IsCA` checking at `loadAndVerifyCert` function. Just checking that cacert is a x509 certificate. Don't need to be a ca cert, server certificate could also be used to connect `MasterClient`.