### PR TITLE
Fix login to accept a path

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -88,7 +88,14 @@ func loginSetup(ctx *cli.Context) error {
 	if ctx.NArg() == 0 {
 		return cli.ShowCommandHelp(ctx, "login")
 	}
-	serverConfig.URL = ctx.Args().First()
+
+	// Validate the url and drop the path
+	u, err := url.Parse(ctx.Args().First())
+	if err != nil {
+		return err
+	}
+	u.Path = ""
+	serverConfig.URL = u.String()
 
 	if ctx.String("token") != "" {
 		auth := SplitOnColon(ctx.String("token"))


### PR DESCRIPTION
Problem:
login would not work if a path was appended to the server URL

Solution:
Drop paths from the passed in URL