### PR TITLE
Add format flag to lists

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -33,6 +33,12 @@ func ClusterCommand() cli.Command {
 				Description: "Lists all clusters",
 				ArgsUsage:   "None",
 				Action:      clusterLs,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "format",
+						Usage: "'json' or Custom format: '{{.Cluster.ID}} {{.Cluster.Name}}'",
+					},
+				},
 			},
 			{
 				Name:        "create",

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -31,6 +31,10 @@ func NamespaceCommand() cli.Command {
 						Name:  "all-namespaces",
 						Usage: "List all namespaces in the current cluster",
 					},
+					cli.StringFlag{
+						Name:  "format",
+						Usage: "'json' or Custom format: '{{.Namespace.ID}} {{.Namespace.Name}}'",
+					},
 				},
 			},
 			{

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -28,6 +28,12 @@ func NodeCommand() cli.Command {
 				Description: "\nLists all nodes in the current cluster.",
 				ArgsUsage:   "None",
 				Action:      nodeLs,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "format",
+						Usage: "'json' or Custom format: '{{.Node.ID}} {{.Node.Name}}'",
+					},
+				},
 			},
 			{
 				Name:      "delete",

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -26,6 +26,12 @@ func ProjectCommand() cli.Command {
 				Description: "\nLists all projects in the current cluster.",
 				ArgsUsage:   "None",
 				Action:      projectLs,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "format",
+						Usage: "'json' or Custom format: '{{.Project.ID}} {{.Project.Name}}'",
+					},
+				},
 			},
 			{
 				Name:        "create",

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -28,6 +28,10 @@ func PsCommand() cli.Command {
 				Name:  "project",
 				Usage: "project to show workloads for",
 			},
+			cli.StringFlag{
+				Name:  "format",
+				Usage: "'json' or Custom format: '{{.Name}} {{.Image}}'",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Problem:
Users are unable to specify a format on table outputs

Solution:
Add --format flag to allow customization of outputs or json blobs

Issue: https://github.com/rancher/rancher/issues/12314