### PR TITLE
Add description flag to project and namespace

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -43,6 +43,12 @@ func NamespaceCommand() cli.Command {
 				Description: "\nCreates a namespace in the current cluster.",
 				ArgsUsage:   "[NEWPROJECTNAME...]",
 				Action:      namespaceCreate,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "description",
+						Usage: "Description to apply to the namespace",
+					},
+				},
 			},
 			{
 				Name:      "delete",
@@ -116,8 +122,9 @@ func namespaceCreate(ctx *cli.Context) error {
 	}
 
 	newNamespace := &clusterClient.Namespace{
-		Name:      ctx.Args().First(),
-		ProjectID: c.UserConfig.Project,
+		Name:        ctx.Args().First(),
+		ProjectID:   c.UserConfig.Project,
+		Description: ctx.String("description"),
 	}
 
 	_, err = c.ClusterClient.Namespace.Create(newNamespace)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -44,6 +44,10 @@ func ProjectCommand() cli.Command {
 						Name:  "cluster",
 						Usage: "Cluster ID to create the project in",
 					},
+					cli.StringFlag{
+						Name:  "description",
+						Usage: "Description to apply to the project",
+					},
 				},
 			},
 			{
@@ -106,8 +110,9 @@ func projectCreate(ctx *cli.Context) error {
 	}
 
 	newProj := &managementClient.Project{
-		Name:      ctx.Args().First(),
-		ClusterId: clusterID,
+		Name:        ctx.Args().First(),
+		ClusterId:   clusterID,
+		Description: ctx.String("description"),
 	}
 
 	_, err = c.ManagementClient.Project.Create(newProj)


### PR DESCRIPTION
Problem:
When creating a project and namespace no description can be set

Solution:
Add a flag for optionally adding a description

Issue: https://github.com/rancher/rancher/issues/11461