### PR TITLE
Fix version list

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -200,6 +200,7 @@ func clusterCreate(ctx *cli.Context) error {
 			for _, val := range k8sVersions {
 				fmt.Println(val)
 			}
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Problem:
When running `cluster create --k8s-version list` the cluster is still
being created

Solution:
After printing the versions exit

Issue: https://github.com/rancher/rancher/issues/12383