### PR TITLE
Update cluster import to print second option

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -18,6 +18,9 @@ const (
 Imports an existing cluster to be used in rancher by using a generated kubectl 
 command to run in your existing Kubernetes cluster.
 `
+	importClusterNotice = "If you get an error about 'certificate signed by unknown authority' " +
+		"because your Rancher installation is running with an untrusted/self-signed SSL " +
+		"certificate, run the command below instead to bypass the certificate check:"
 )
 
 type ClusterData struct {
@@ -250,7 +253,7 @@ func clusterImport(ctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("Run the following command in your cluster: %v\n", clusterToken.Command)
+	fmt.Printf("Run the following command in your cluster:\n%s\n\n%s\n%s\n", clusterToken.Command, importClusterNotice, clusterToken.InsecureCommand)
 
 	return nil
 }


### PR DESCRIPTION
Problem:
Some rancher servers are running SSL certs that fail validation so an
existing k8s cluster would not import through a standard kubectl call

Solution:
Output a second option using curl to download the file and pass it to
kubectl thus avoiding the SSL check

Issue: https://github.com/rancher/rancher/issues/12382