### PR TITLE
Update project create and ps to use lookup by name

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -145,11 +145,11 @@ func projectCreate(ctx *cli.Context) error {
 
 	clusterID := c.UserConfig.FocusedCluster()
 	if ctx.String("cluster") != "" {
-		cluster, err := getClusterByID(c, ctx.String("cluster"))
+		resource, err := Lookup(c, ctx.String("cluster"), "cluster")
 		if nil != err {
 			return err
 		}
-		clusterID = cluster.ID
+		clusterID = resource.ID
 	}
 
 	newProj := &managementClient.Project{

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -19,14 +19,21 @@ type PSHolder struct {
 
 func PsCommand() cli.Command {
 	return cli.Command{
-		Name:        "ps",
-		Usage:       "Show workloads and pods",
-		Description: "Prints out a table of pods not associated with a workload then a table of workloads",
-		Action:      psLs,
+		Name:  "ps",
+		Usage: "Show workloads in a project",
+		Description: `Show information on the workloads in a project. Defaults to the current context.
+Examples:
+	# Show workloads in the current context
+	$ rancher ps
+
+	#Show workloads in a specific project and output the results in yaml
+	$ rancher ps --project projectFoo --format yaml
+`,
+		Action: psLs,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "project",
-				Usage: "project to show workloads for",
+				Usage: "Optional project to show workloads for",
 			},
 			cli.StringFlag{
 				Name:  "format",
@@ -49,16 +56,11 @@ func psLs(ctx *cli.Context) error {
 			return err
 		}
 
-		_, err = getProjectByID(c, resource.ID)
-		if nil != err {
-			return err
-		}
-
 		sc, err := lookupConfig(ctx)
 		if nil != err {
 			return err
 		}
-		sc.Project = ctx.String("project")
+		sc.Project = resource.ID
 
 		projClient, err := cliclient.NewProjectClient(sc)
 		if nil != err {


### PR DESCRIPTION
Problem:
Specifying a cluster on project create and a project using ps required
an ID

Solution:
Use the lookup by name
Update the description of the ps command

Issue: https://github.com/rancher/rancher/issues/11469