### PR TITLE
Update ssh to accept users and pass through all args

### DIFF
--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -26,7 +26,7 @@ Examples:
 	# Show workloads in the current context
 	$ rancher ps
 
-	#Show workloads in a specific project and output the results in yaml
+	# Show workloads in a specific project and output the results in yaml
 	$ rancher ps --project projectFoo --format yaml
 `,
 		Action: psLs,


### PR DESCRIPTION
Problem:
SSH command does not accept a user or allow passing through of commands

Solution:
Add support for -l flag as well as <user>@<node> syntax
Pass through all following args to SSH

SSH can be called in three ways:
`rancher ssh <node>`
`rancher ssh -l <user> <node>`
`rancher ssh <user>@<node>`

Issue: https://github.com/rancher/rancher/issues/12897