### PR TITLE
Fix context switch

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -74,6 +74,8 @@ func contextSwitch(ctx *cli.Context) error {
 
 	logrus.Infof("Setting new context to project %s", project.Name)
 
+	server.Project = project.ID
+
 	cf.Write()
 
 	return nil

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -86,7 +86,7 @@ func loginSetup(ctx *cli.Context) error {
 
 	serverName := ctx.String("name")
 	if serverName == "" {
-		serverName = RandomName()
+		serverName = "rancherDefault"
 	}
 
 	serverConfig := &config.ServerConfig{}


### PR DESCRIPTION
Problem:
Context is not setting the new project correctly

Solution:
Save the selected project into the users config
Stop using a random name on login, this was causing the json file to grow and no way for a user to get back to using a previous config. Use a default name if none is provided.

Issue: https://github.com/rancher/rancher/issues/13235