### PR TITLE
Update catalog and help output

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -11,10 +11,10 @@ Add a new catalog to the Rancher server
 
 Example:
 	# Add a catalog
-	$ rancher add-catalog foo https://my.catalog
+	$ rancher catalog add foo https://my.catalog
 
 	# Add a catalog and specify the branch to use
-	$ rancher add-catalog --branch awesomebranch foo https://my.catalog
+	$ rancher catalog add --branch awesomebranch foo https://my.catalog
 `
 )
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ Run '{{.Name}} COMMAND --help' for more information on a command.
 var CommandHelpTemplate = `{{.Usage}}
 {{if .Description}}{{.Description}}{{end}}
 Usage: 
-	rancher {{.Name}} {{if .Flags}}[OPTIONS] {{end}}{{if ne "None" .ArgsUsage}}{{if ne "" .ArgsUsage}}{{.ArgsUsage}}{{else}}[arg...]{{end}}{{end}}
+	{{.HelpName}} {{if .Flags}}[OPTIONS] {{end}}{{if ne "None" .ArgsUsage}}{{if ne "" .ArgsUsage}}{{.ArgsUsage}}{{else}}[arg...]{{end}}{{end}}
 
 {{if .Flags}}Options:{{range .Flags}}
 	 {{.}}{{end}}{{end}}


### PR DESCRIPTION
Problem:
Catalog add had the wrong command
Help output was not showing parent commands

Solution:
Fix the type
Update template to display full command

Issue: https://github.com/rancher/rancher/issues/13447