### PR TITLE
 Add timeout flag to login command

### DIFF
--- a/cliclient/cliclient.go
+++ b/cliclient/cliclient.go
@@ -146,6 +146,7 @@ func createClientOpts(config *config.ServerConfig) *clientbase.ClientOpts {
 		AccessKey: config.AccessKey,
 		SecretKey: config.SecretKey,
 		CACerts:   config.CACerts,
+		Timeout:   config.Timeout,
 	}
 	return options
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,7 +51,7 @@ func LoginCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  "timeout",
-				Usage: "Connection Timeout",
+				Usage: "Connection Timeout in seconds",
 			},
 			cli.StringFlag{
 				Name:  "cacert",
@@ -102,6 +102,7 @@ func loginSetup(ctx *cli.Context) error {
 	}
 	u.Path = ""
 	serverConfig.URL = u.String()
+
 	serverConfig.Timeout = 0
 	if ctx.String("timeout") != "" {
 		timeoutParameter := ctx.String("timeout")

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
+	"time"
 	"github.com/sirupsen/logrus"
 
 	"github.com/grantae/certinfo"
@@ -48,6 +48,10 @@ func LoginCommand() cli.Command {
 			cli.StringFlag{
 				Name:  "token,t",
 				Usage: "Token from the Rancher UI",
+			},
+			cli.StringFlag{
+				Name:  "timeout",
+				Usage: "Connection Timeout",
 			},
 			cli.StringFlag{
 				Name:  "cacert",
@@ -98,6 +102,15 @@ func loginSetup(ctx *cli.Context) error {
 	}
 	u.Path = ""
 	serverConfig.URL = u.String()
+	serverConfig.Timeout = 0
+	if ctx.String("timeout") != "" {
+		timeoutParameter := ctx.String("timeout")
+		timeout, err := strconv.Atoi(timeoutParameter)
+		if err != nil {
+			return err
+		}
+		serverConfig.Timeout = time.Duration(timeout)*time.Second
+	}
 
 	if ctx.String("token") != "" {
 		auth := SplitOnColon(ctx.String("token"))

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	"time"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,7 @@ type ServerConfig struct {
 	URL       string `json:"url"`
 	Project   string `json:"project"`
 	CACerts   string `json:"cacert"`
+	Timeout	  time.Duration	 `json:"timeout"`
 }
 
 func (c Config) Write() error {


### PR DESCRIPTION
I ran into the same issue as mentioned here: https://github.com/rancher/rancher/issues/8654
So i added the timeout-Flag to the login command and cli2.json. 

```
$: rancher login --timeout 60 --token <token> <server-url> ...
```

During build process, i also had to add a `ENV GIT_SSL_NO_VERIFY 1` to the Dockerfile.dapper file. Without i got the following error:
```
$: CROSS=1 make build`
./.dapper build
Sending build context to Docker daemon  15.01MB
Step 1/14 : FROM golang:1.9.4
 ---> a6c306bd0b2f
Step 2/14 : RUN apt-get update &&     apt-get install -y xz-utils zip rsync
 ---> Using cache
 ---> aad259231aeb
Step 3/14 : RUN go get github.com/rancher/trash
 ---> Running in 1990c07bc7af
# cd .; git clone https://github.com/rancher/trash /go/src/github.com/rancher/trash
Cloning into '/go/src/github.com/rancher/trash'...
fatal: unable to access 'https://github.com/rancher/trash/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
package github.com/rancher/trash: exit status 128
The command '/bin/sh -c go get github.com/rancher/trash' returned a non-zero code: 1
FATA[0003] exit status 1
make: *** [build] Error 1
```
I don't include this line in this Pull-Request because i don't know if its only a local problem.