### PR TITLE
Fix app namespace issue

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"strconv"
@@ -28,6 +29,8 @@ import (
 	managementClient "github.com/rancher/types/client/management/v3"
 	"github.com/urfave/cli"
 )
+
+const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 var (
 	errNoURL = errors.New("RANCHER_URL environment or --Url is not set, run `login`")
@@ -364,6 +367,16 @@ func Lookup(c *cliclient.MasterClient, name string, types ...string) (*ntypes.Re
 
 func RandomName() string {
 	return strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1)
+}
+
+// RandomLetters returns a string with random letters of length n
+func RandomLetters(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }
 
 func appendTabDelim(buf *bytes.Buffer, value string) {


### PR DESCRIPTION
Problem:
Apps of the same name deploy into the same namespace. This fails when a
namespace is owned by another project

Solution:
Apps should be deployed into a unique namespace unless specified
otherwise.
Add a flag to specify the namespace
Create a namespace with a random suffix to deploy the app into if
namespace is not specified

Issue: https://github.com/rancher/rancher/issues/13537