### PR TITLE
Wait for namespace to be ready

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -19,6 +19,9 @@ func NamespaceCommand() cli.Command {
 		Aliases: []string{"namespace"},
 		Usage:   "Operations on namespaces",
 		Action:  defaultAction(namespaceLs),
+		Flags: []cli.Flag{
+			quietFlag,
+		},
 		Subcommands: []cli.Command{
 			{
 				Name:        "ls",


### PR DESCRIPTION
Problem:
An app creates a namespace to deploy into and depending on the system it
might not be ready when attempting to install the app

Solution:
Poll the namespace to ensure it's active before proceeding with
installing the app

Issue: https://github.com/rancher/rancher/issues/13567