### PR TITLE
Added support for corporate proxy variables.

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -233,6 +233,7 @@ func getCertFromServer(cf *config.ServerConfig) (*cliclient.MasterClient, error)
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	client := &http.Client{Transport: tr}
 

--- a/vendor/github.com/rancher/norman/clientbase/common.go
+++ b/vendor/github.com/rancher/norman/clientbase/common.go
@@ -192,6 +192,7 @@ func NewAPIClient(opts *ClientOpts) (APIBaseClient, error) {
 			TLSClientConfig: &tls.Config{
 				RootCAs: roots,
 			},
+			Proxy: http.ProxyFromEnvironment,
 		}
 		client.Transport = tr
 	}
@@ -201,6 +202,7 @@ func NewAPIClient(opts *ClientOpts) (APIBaseClient, error) {
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: opts.Insecure,
 			},
+			Proxy: http.ProxyFromEnvironment,
 		}
 		client.Transport = tr
 	}


### PR DESCRIPTION
Hi,

my company has a corporate proxy. rancher-cli runs behind that. Our rancher 2 server instance runs in the public internet.

We want the rancher-cli to connect to the rancher 2 server.

Our corporate proxy prevents rancher-cli from connecting to the internet. The http_proxy, ... variables are ignored.

I added support for environment variables to all calls of 

```
   http.Transport(...)
```

Now it works.

Accept this PR, please.

Thanks a lot and best regards,

Josef


