### PR TITLE
Catch invalid JSON response from server on login

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -259,6 +259,9 @@ func getCertFromServer(cf *config.ServerConfig) (*cliclient.MasterClient, error)
 
 	var certReponse *CACertResponse
 	err = json.Unmarshal(content, &certReponse)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse response from %s/v3/settings/cacerts\nError: %s\nResponse:\n%s", cf.URL, err, content)
+	}
 
 	cert, err := verifyCert([]byte(certReponse.Value))
 	if nil != err {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/15235

```
$ ./rancher_darwin-amd64 login https://self-signed.badssl.com --token a:b
FATA[0000] Unable to parse response from https://self-signed.badssl.com/v3/settings/cacerts
Error: invalid character '<' looking for beginning of value
Response:
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.10.3 (Ubuntu)</center>
</body>
</html>
```