### PR TITLE
update golint path to fix ci

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,7 +2,7 @@ FROM golang:1.9.4
 RUN apt-get update && \
     apt-get install -y xz-utils zip rsync
 RUN go get github.com/rancher/trash
-RUN go get github.com/golang/lint/golint
+RUN go get golang.org/x/lint/golint
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/docker && \
     chmod +x /usr/bin/docker
 ENV PATH /go/bin:$PATH


### PR DESCRIPTION
Current CI steps return the following error
```
package github.com/golang/lint/golint: code in directory /go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
The command '/bin/sh -c go get github.com/golang/lint/golint' returned a non-zero code: 1
time="2018-10-23T01:28:39Z" level=fatal msg="exit status 1"  
```
Because the golint import path moved from github to golang.org: https://github.com/golang/lint/commit/c363707d68842c977f911634e06201907b60ce58#diff-5d137a611fd4de5bdbf3200f5cf19ef6