### PR TITLE
Allow equal signs to appear in the value part of an answer

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -832,7 +832,7 @@ func processAnswers(
 	}
 
 	for _, answer := range ctx.StringSlice("set") {
-		parts := strings.Split(answer, "=")
+		parts := strings.SplitN(answer, "=", 2)
 		if len(parts) == 2 {
 			answers[parts[0]] = parts[1]
 		}


### PR DESCRIPTION
If an answer had an equals sign within the value portion of the answer, then the answer would be silently ignored and not included in the request to the rancher server.

For example,

```console
$ rancher app install --set my.foo="a-string-with-a-=-sign" . my-app
```

Would attempt to install the chart as my-app, but the request payload would not include my.foo.

Change respects only the first equal sign within the answer and then takes all that follows as the value.