### PR TITLE
add catalog refresh

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -28,8 +28,8 @@ const (
 	installAppDescription = `
 Install an app template in the current Rancher server. This defaults to the newest version of the app template.
 Specify a version using '--version' if required.
-The app will be installed into a new namespace unless '--namespace' is specified. 
-					
+The app will be installed into a new namespace unless '--namespace' is specified.
+
 Example:
 	# Install the redis template with no other options
 	$ rancher app install redis appFoo
@@ -794,7 +794,7 @@ func createNamespace(c *cliclient.MasterClient, n string) error {
 
 		startTime := time.Now()
 		for {
-			logrus.Debug(fmt.Sprintf("Namespace create wait - Name: %s, State: %s, Transitioning: %s", ns.Name, ns.State, ns.Transitioning))
+			logrus.Debugf("Namespace create wait - Name: %s, State: %s, Transitioning: %s", ns.Name, ns.State, ns.Transitioning)
 			if time.Since(startTime)/time.Second > 30 {
 				return fmt.Errorf("timed out waiting for new namespace %s", ns.Name)
 			}

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -36,6 +36,9 @@ Example:
 
 	# Refresh is asynchronous unless you specify '--wait'
 	$ rancher catalog refresh --all --wait --wait-timeout=60
+
+	# Default wait timeout is 60 seconds, set to 0 to remove the timeout
+	$ rancher catalog refresh --all --wait --wait-timeout=0
 `
 )
 
@@ -107,7 +110,7 @@ func CatalogCommand() cli.Command {
 					cli.IntFlag{
 						Name:  "wait-timeout",
 						Usage: "Wait timeout duration in seconds",
-						Value: 0,
+						Value: 60,
 					},
 				},
 			},
@@ -278,6 +281,7 @@ func catalogRefresh(ctx *cli.Context) error {
 			}
 
 			for catalog.State != "active" {
+				time.Sleep(time.Second)
 				catalog, err = c.ManagementClient.Catalog.ByID(resource.ID)
 				if err != nil {
 					return err


### PR DESCRIPTION
Allows refreshing catalogs via the CLI.

For example:
```bash
# Refresh a catalog
$ rancher catalog refresh foo

 # Refresh multiple catalogs
$ rancher catalog refresh foo bar baz

 # Refresh all catalogs
$ rancher catalog refresh --all
```