### PR TITLE
CLI no longer returns a 404 error upon issuing project ls command.

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/rancher/cli/cliclient"
 	managementClient "github.com/rancher/types/client/management/v3"
@@ -107,7 +108,21 @@ func ProjectCommand() cli.Command {
 func projectLs(ctx *cli.Context) error {
 	c, err := GetClient(ctx)
 	if err != nil {
-		return err
+		path := ctx.GlobalString("cf")
+		if path == "" {
+			path = os.ExpandEnv("${HOME}/.rancher/cli2.json")
+		}
+		config, err := loadConfig(path)
+		if err != nil {
+			return err
+		}
+		currServer := config.CurrentServer
+		config.Servers[currServer].Project = ""
+		config.Write()
+		c, err = GetClient(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	collection, err := getProjectList(ctx, c)


### PR DESCRIPTION
CLI no longer returns a 404 upon issuing a rancher project ls command.
This would happen in the scenario where a user switch the command
add-local from true to false. Upon running project ls, if an error is
encountered then the cli config will clear the project name value, then
continue. Expected behavior is to receive a warning informing a user
that they have no project and should login to the cli again.