### PR TITLE
Allow for local cluster when parsing context

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -486,7 +486,7 @@ func parseClusterAndProjectID(id string) (string, string, error) {
 	// c-qmpbm:p-mm62v
 	// c-qmpbm:project-mm62v
 	// See https://github.com/rancher/rancher/issues/14400
-	if match, _ := regexp.MatchString("c-[[:alnum:]]{5}:(p|project)-[[:alnum:]]{5}", id); match {
+	if match, _ := regexp.MatchString("((local)|(c-[[:alnum:]]{5})):(p|project)-[[:alnum:]]{5}", id); match {
 		parts := SplitOnColon(id)
 		return parts[0], parts[1], nil
 	}

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+type CommonTestSuite struct {
+}
+
+var _ = check.Suite(&CommonTestSuite{})
+
+func (s *CommonTestSuite) SetUpSuite(c *check.C) {
+
+}
+
+func (s *CommonTestSuite) TestParseClusterAndProjectID(c *check.C) {
+	testParse(c, "local:p-12345", "local", "p-12345", false)
+	testParse(c, "c-12345:p-12345", "c-12345", "p-12345", false)
+	testParse(c, "cocal:p-12345", "", "", true)
+	testParse(c, "c-123:p-123", "", "", true)
+	testParse(c, "", "", "", true)
+}
+
+func testParse(c *check.C, testID, expectedCluster, expectedProject string, errorExpected bool) {
+	actualCluster, actualProject, actualErr := parseClusterAndProjectID(testID)
+	c.Assert(actualCluster, check.Equals, expectedCluster)
+	c.Assert(actualProject, check.Equals, expectedProject)
+	if errorExpected {
+		c.Assert(actualErr, check.NotNil)
+	} else {
+		c.Assert(actualErr, check.IsNil)
+	}
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -154,7 +154,7 @@ func getProjectContext(ctx *cli.Context, c *cliclient.MasterClient) (string, err
 		// Check if given context is in valid format
 		_, _, err := parseClusterAndProjectID(context)
 		if err != nil {
-			return "", fmt.Errorf("Unable to parse context (%s). Please provide context as c-xxxxx:p-xxxxx or c-xxxxx:project-xxxxx", context)
+			return "", fmt.Errorf("Unable to parse context (%s). Please provide context as local:p-xxxxx, c-xxxxx:p-xxxxx, or c-xxxxx:project-xxxxx", context)
 		}
 		// Check if context exists
 		_, err = Lookup(c, context, "project")


### PR DESCRIPTION
"local" is a valid cluster id. Our parsing function wasn't allowing
for it.

https://github.com/rancher/rancher/issues/17647