### PR TITLE
Address mcapp RBAC changes

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -165,7 +165,7 @@ func searchForMember(ctx *cli.Context, c *cliclient.MasterClient, name string) (
 	dataLength := len(results.Data)
 	switch {
 	case dataLength == 0:
-		return nil, errors.New("no results found")
+		return nil, fmt.Errorf("no results found for %q", name)
 	case dataLength == 1:
 		return &results.Data[0], nil
 	case dataLength >= 10:

--- a/vendor.conf
+++ b/vendor.conf
@@ -27,5 +27,5 @@ github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0
 github.com/stretchr/testify v1.2.2
 
-github.com/rancher/norman fe50543a2e84d5c77ec8fa91f8fc082b67de7072
-github.com/rancher/types 9577885c7a5818696ff24e7a9fc5a5059692ed49
+github.com/rancher/norman 457c15b94acae52afb5290aa315452c7621d452a
+github.com/rancher/types 0f5ebf405a9c84f4fef43665ac58a118be4d5657

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog_template_version.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_catalog_template_version.go
@@ -29,6 +29,9 @@ const (
 	CatalogTemplateVersionFieldUUID                 = "uuid"
 	CatalogTemplateVersionFieldUpgradeVersionLinks  = "upgradeVersionLinks"
 	CatalogTemplateVersionFieldVersion              = "version"
+	CatalogTemplateVersionFieldVersionDir           = "versionDir"
+	CatalogTemplateVersionFieldVersionName          = "versionName"
+	CatalogTemplateVersionFieldVersionURLs          = "versionUrls"
 )
 
 type CatalogTemplateVersion struct {
@@ -56,6 +59,9 @@ type CatalogTemplateVersion struct {
 	UUID                 string                 `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	UpgradeVersionLinks  map[string]string      `json:"upgradeVersionLinks,omitempty" yaml:"upgradeVersionLinks,omitempty"`
 	Version              string                 `json:"version,omitempty" yaml:"version,omitempty"`
+	VersionDir           string                 `json:"versionDir,omitempty" yaml:"versionDir,omitempty"`
+	VersionName          string                 `json:"versionName,omitempty" yaml:"versionName,omitempty"`
+	VersionURLs          []string               `json:"versionUrls,omitempty" yaml:"versionUrls,omitempty"`
 }
 
 type CatalogTemplateVersionCollection struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster.go
@@ -118,6 +118,8 @@ type ClusterOperations interface {
 
 	ActionDisableMonitoring(resource *Cluster) error
 
+	ActionEditMonitoring(resource *Cluster, input *MonitoringInput) error
+
 	ActionEnableMonitoring(resource *Cluster, input *MonitoringInput) error
 
 	ActionExportYaml(resource *Cluster) (*ExportOutput, error)
@@ -129,6 +131,8 @@ type ClusterOperations interface {
 	ActionRestoreFromEtcdBackup(resource *Cluster, input *RestoreFromEtcdBackupInput) error
 
 	ActionRotateCertificates(resource *Cluster, input *RotateCertificateInput) (*RotateCertificateOutput, error)
+
+	ActionViewMonitoring(resource *Cluster) (*MonitoringOutput, error)
 }
 
 func newClusterClient(apiClient *Client) *ClusterClient {
@@ -192,6 +196,11 @@ func (c *ClusterClient) ActionDisableMonitoring(resource *Cluster) error {
 	return err
 }
 
+func (c *ClusterClient) ActionEditMonitoring(resource *Cluster, input *MonitoringInput) error {
+	err := c.apiClient.Ops.DoAction(ClusterType, "editMonitoring", &resource.Resource, input, nil)
+	return err
+}
+
 func (c *ClusterClient) ActionEnableMonitoring(resource *Cluster, input *MonitoringInput) error {
 	err := c.apiClient.Ops.DoAction(ClusterType, "enableMonitoring", &resource.Resource, input, nil)
 	return err
@@ -223,5 +232,11 @@ func (c *ClusterClient) ActionRestoreFromEtcdBackup(resource *Cluster, input *Re
 func (c *ClusterClient) ActionRotateCertificates(resource *Cluster, input *RotateCertificateInput) (*RotateCertificateOutput, error) {
 	resp := &RotateCertificateOutput{}
 	err := c.apiClient.Ops.DoAction(ClusterType, "rotateCertificates", &resource.Resource, input, resp)
+	return resp, err
+}
+
+func (c *ClusterClient) ActionViewMonitoring(resource *Cluster) (*MonitoringOutput, error) {
+	resp := &MonitoringOutput{}
+	err := c.apiClient.Ops.DoAction(ClusterType, "viewMonitoring", &resource.Resource, nil, resp)
 	return resp, err
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_monitoring_output.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_monitoring_output.go
@@ -1,0 +1,10 @@
+package client
+
+const (
+	MonitoringOutputType         = "monitoringOutput"
+	MonitoringOutputFieldAnswers = "answers"
+)
+
+type MonitoringOutput struct {
+	Answers map[string]string `json:"answers,omitempty" yaml:"answers,omitempty"`
+}

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_project.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_project.go
@@ -74,11 +74,15 @@ type ProjectOperations interface {
 
 	ActionDisableMonitoring(resource *Project) error
 
+	ActionEditMonitoring(resource *Project, input *MonitoringInput) error
+
 	ActionEnableMonitoring(resource *Project, input *MonitoringInput) error
 
 	ActionExportYaml(resource *Project) error
 
 	ActionSetpodsecuritypolicytemplate(resource *Project, input *SetPodSecurityPolicyTemplateInput) (*Project, error)
+
+	ActionViewMonitoring(resource *Project) (*MonitoringOutput, error)
 }
 
 func newProjectClient(apiClient *Client) *ProjectClient {
@@ -137,6 +141,11 @@ func (c *ProjectClient) ActionDisableMonitoring(resource *Project) error {
 	return err
 }
 
+func (c *ProjectClient) ActionEditMonitoring(resource *Project, input *MonitoringInput) error {
+	err := c.apiClient.Ops.DoAction(ProjectType, "editMonitoring", &resource.Resource, input, nil)
+	return err
+}
+
 func (c *ProjectClient) ActionEnableMonitoring(resource *Project, input *MonitoringInput) error {
 	err := c.apiClient.Ops.DoAction(ProjectType, "enableMonitoring", &resource.Resource, input, nil)
 	return err
@@ -150,5 +159,11 @@ func (c *ProjectClient) ActionExportYaml(resource *Project) error {
 func (c *ProjectClient) ActionSetpodsecuritypolicytemplate(resource *Project, input *SetPodSecurityPolicyTemplateInput) (*Project, error) {
 	resp := &Project{}
 	err := c.apiClient.Ops.DoAction(ProjectType, "setpodsecuritypolicytemplate", &resource.Resource, input, resp)
+	return resp, err
+}
+
+func (c *ProjectClient) ActionViewMonitoring(resource *Project) (*MonitoringOutput, error) {
+	resp := &MonitoringOutput{}
+	err := c.apiClient.Ops.DoAction(ProjectType, "viewMonitoring", &resource.Resource, nil, resp)
 	return resp, err
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_target.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_target.go
@@ -5,10 +5,12 @@ const (
 	TargetFieldAppID       = "appId"
 	TargetFieldHealthstate = "healthState"
 	TargetFieldProjectID   = "projectId"
+	TargetFieldState       = "state"
 )
 
 type Target struct {
 	AppID       string `json:"appId,omitempty" yaml:"appId,omitempty"`
 	Healthstate string `json:"healthState,omitempty" yaml:"healthState,omitempty"`
 	ProjectID   string `json:"projectId,omitempty" yaml:"projectId,omitempty"`
+	State       string `json:"state,omitempty" yaml:"state,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version.go
@@ -29,6 +29,9 @@ const (
 	TemplateVersionFieldUUID                 = "uuid"
 	TemplateVersionFieldUpgradeVersionLinks  = "upgradeVersionLinks"
 	TemplateVersionFieldVersion              = "version"
+	TemplateVersionFieldVersionDir           = "versionDir"
+	TemplateVersionFieldVersionName          = "versionName"
+	TemplateVersionFieldVersionURLs          = "versionUrls"
 )
 
 type TemplateVersion struct {
@@ -56,6 +59,9 @@ type TemplateVersion struct {
 	UUID                 string                 `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 	UpgradeVersionLinks  map[string]string      `json:"upgradeVersionLinks,omitempty" yaml:"upgradeVersionLinks,omitempty"`
 	Version              string                 `json:"version,omitempty" yaml:"version,omitempty"`
+	VersionDir           string                 `json:"versionDir,omitempty" yaml:"versionDir,omitempty"`
+	VersionName          string                 `json:"versionName,omitempty" yaml:"versionName,omitempty"`
+	VersionURLs          []string               `json:"versionUrls,omitempty" yaml:"versionUrls,omitempty"`
 }
 
 type TemplateVersionCollection struct {

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_template_version_spec.go
@@ -13,6 +13,9 @@ const (
 	TemplateVersionSpecFieldRequiredNamespace   = "requiredNamespace"
 	TemplateVersionSpecFieldUpgradeVersionLinks = "upgradeVersionLinks"
 	TemplateVersionSpecFieldVersion             = "version"
+	TemplateVersionSpecFieldVersionDir          = "versionDir"
+	TemplateVersionSpecFieldVersionName         = "versionName"
+	TemplateVersionSpecFieldVersionURLs         = "versionUrls"
 )
 
 type TemplateVersionSpec struct {
@@ -27,4 +30,7 @@ type TemplateVersionSpec struct {
 	RequiredNamespace   string            `json:"requiredNamespace,omitempty" yaml:"requiredNamespace,omitempty"`
 	UpgradeVersionLinks map[string]string `json:"upgradeVersionLinks,omitempty" yaml:"upgradeVersionLinks,omitempty"`
 	Version             string            `json:"version,omitempty" yaml:"version,omitempty"`
+	VersionDir          string            `json:"versionDir,omitempty" yaml:"versionDir,omitempty"`
+	VersionName         string            `json:"versionName,omitempty" yaml:"versionName,omitempty"`
+	VersionURLs         []string          `json:"versionUrls,omitempty" yaml:"versionUrls,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_multi_cluster_app_targets_input.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_multi_cluster_app_targets_input.go
@@ -7,6 +7,6 @@ const (
 )
 
 type UpdateMultiClusterAppTargetsInput struct {
-	Answers  []string `json:"answers,omitempty" yaml:"answers,omitempty"`
+	Answers  []Answer `json:"answers,omitempty" yaml:"answers,omitempty"`
 	Projects []string `json:"projects,omitempty" yaml:"projects,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
+++ b/vendor/github.com/rancher/types/client/project/v3/zz_generated_app_upgrade_config.go
@@ -6,6 +6,7 @@ const (
 	AppUpgradeConfigFieldExternalID   = "externalId"
 	AppUpgradeConfigFieldFiles        = "files"
 	AppUpgradeConfigFieldForceUpgrade = "forceUpgrade"
+	AppUpgradeConfigFieldValuesYaml   = "valuesYaml"
 )
 
 type AppUpgradeConfig struct {
@@ -13,4 +14,5 @@ type AppUpgradeConfig struct {
 	ExternalID   string            `json:"externalId,omitempty" yaml:"externalId,omitempty"`
 	Files        map[string]string `json:"files,omitempty" yaml:"files,omitempty"`
 	ForceUpgrade bool              `json:"forceUpgrade,omitempty" yaml:"forceUpgrade,omitempty"`
+	ValuesYaml   string            `json:"valuesYaml,omitempty" yaml:"valuesYaml,omitempty"`
 }


### PR DESCRIPTION
Address issue:
https://github.com/rancher/rancher/issues/17147
https://github.com/rancher/rancher/issues/17981

Related types PR: https://github.com/rancher/types/pull/726

- Add subcommand for updating target projects
- Add subcommand for updating members
- Add --member, --member-access-type option on install
- Add --role option on install/upgrade
- Add member/role details in show-app command

Examples:
```
#update targets command:
1. rancher mcapp add-project myapp mycluster:Project1 mycluster:Project2
2. rancher mcapp delete-project myapp mycluster:Project1 mycluster:Project2
# update member command:
3. rancher mcapp add-member myapp owner user1 user2
4. rancher mcapp delete-member myapp user1 user2
# set members on installation
5. rancher mcapp install --member user1 --member-access-type member --target mycluster:Default mysql myapp
# set roles on install/upgrade
6. rancher mcapp install --role project-owner --target mycluster:Default mysql myapp
7. rancher mcapp upgrade --role project-owner myapp 0.3.8
# show app command
8. rancher mcapp sa myapp
CURRENT   REVISION              CREATED
*         mcapprevision-rhcw9   18 Feb 2019 05:10:39 UTC
          mcapprevision-gmzgh   18 Feb 2019 05:10:00 UTC

CURRENT   VERSION
          0.3.7
*         0.3.8

MEMBER_NAME     MEMBER_TYPE   ACCESS_TYPE
Default Admin   Local User    owner

ROLE_NAME
cluster-owner
project-owner
```