### PR TITLE
Fix panic on mcapp install

### DIFF
--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -622,6 +622,10 @@ func multiClusterAppTemplateInstall(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		if madeApp.Status == nil {
+			// The status can be nil before any condition is initialized. Wait for conditions to be available in this case.
+			continue
+		}
 		for _, condition := range madeApp.Status.Conditions {
 			condType := strings.ToLower(condition.Type)
 			condStatus := strings.ToLower(condition.Status)


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/18670

Problem:
Panic happens on mcapp install when talking to a 2C4G single node K8S with Rancher HA installed and a GKE cluster provisioned. It does not happen in a standalone rancher. 
Inspecting the code, it is probably because the heavy loaded Rancher/K8S takes longer time to handle the conditions thus we get nil status when fetching the mcapp object after it is created.