### PR TITLE
Add roles in add/delete-member API input

### DIFF
--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -864,6 +864,7 @@ func addMcappMember(ctx *cli.Context) error {
 
 	update := make(map[string]interface{})
 	update["members"] = members
+	update["roles"] = app.Roles
 
 	_, err = c.ManagementClient.MultiClusterApp.Update(app, update)
 	return err
@@ -894,6 +895,7 @@ func deleteMcappMember(ctx *cli.Context) error {
 
 	update := make(map[string]interface{})
 	update["members"] = members
+	update["roles"] = app.Roles
 
 	_, err = c.ManagementClient.MultiClusterApp.Update(app, update)
 	return err


### PR DESCRIPTION
Address https://github.com/rancher/rancher/issues/17981#issuecomment-471649787

Problem:
When using add-member/delete-member commands, missing roles on updating mcapp
is rejected on API layer.

Solution:
Add existing roles to the input.