### PR TITLE
Mcapp enhancements

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -639,4 +640,13 @@ func deleteMembersByNames(ctx *cli.Context, c *cliclient.MasterClient, members [
 		members = toKeepMembers
 	}
 	return members, nil
+}
+
+func tickerContext(ctx context.Context, duration time.Duration) <-chan time.Time {
+	ticker := time.NewTicker(duration)
+	go func() {
+		<-ctx.Done()
+		ticker.Stop()
+	}()
+	return ticker.C
 }

--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -208,6 +208,10 @@ func MultiClusterAppCommand() cli.Command {
 						Name:  argUpgradeBatchInterval,
 						Usage: "The number of seconds between updating the next app during upgrade.  Only used if --upgrade-strategy is rolling-update.",
 					},
+					cli.BoolFlag{
+						Name:  "rollback",
+						Usage: "Rollback to previous revision when the upgrade fails",
+					},
 					timeoutFlag,
 				},
 			},
@@ -563,6 +567,25 @@ func multiClusterAppUpgrade(ctx *cli.Context) error {
 	if _, err := c.ManagementClient.MultiClusterApp.Update(app, update); err != nil {
 		return err
 	}
+
+	err = waitUntilMultiClusterAppActive(c, app.ID, ctx.Int(argTimeout))
+	if err == nil || !ctx.Bool("rollback") {
+		return err
+	}
+
+	logrus.WithError(err).Errorf("failed to upgrade multi-cluster app %q. Rolling back to previous revision", app.Name)
+
+	if app.Status == nil {
+		return errors.New("revision is unknown")
+	}
+
+	rr := &managementClient.MultiClusterAppRollbackInput{
+		RevisionID: app.Status.RevisionID,
+	}
+	if err := c.ManagementClient.MultiClusterApp.ActionRollback(app, rr); err != nil {
+		return err
+	}
+
 	return waitUntilMultiClusterAppActive(c, app.ID, ctx.Int(argTimeout))
 }
 

--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -491,7 +491,7 @@ func multiClusterAppUpgrade(ctx *cli.Context) error {
 		return outputMultiClusterAppVersions(ctx, c, app)
 	}
 
-	if ctx.NArg() < 2 {
+	if ctx.NArg() != 2 {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 
@@ -521,7 +521,19 @@ func multiClusterAppUpgrade(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	update["templateVersionId"] = strings.TrimSuffix(templateVersion.ID, templateVersion.Version) + version
+	toUpgradeTemplateversionID := strings.TrimSuffix(templateVersion.ID, templateVersion.Version) + version
+	// Check if the template version is valid before applying it
+	templateVersion, err = c.ManagementClient.TemplateVersion.ByID(toUpgradeTemplateversionID)
+	if err != nil {
+		templateName := strings.TrimSuffix(toUpgradeTemplateversionID, "-"+version)
+		return fmt.Errorf(
+			"version %s for template %s is invalid, run 'rancher mcapp show-template %s' for available versions",
+			version,
+			templateName,
+			templateName,
+		)
+	}
+	update["templateVersionId"] = toUpgradeTemplateversionID
 
 	roles := ctx.StringSlice("role")
 	if len(roles) > 0 {
@@ -564,7 +576,7 @@ func multiClusterAppRollback(ctx *cli.Context) error {
 		return outputMultiClusterAppRevisions(ctx, c, resource, app)
 	}
 
-	if ctx.NArg() < 2 {
+	if ctx.NArg() != 2 {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 
@@ -581,7 +593,7 @@ func multiClusterAppRollback(ctx *cli.Context) error {
 }
 
 func multiClusterAppTemplateInstall(ctx *cli.Context) error {
-	if ctx.NArg() == 0 {
+	if ctx.NArg() != 2 {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 	templateName := ctx.Args().First()


### PR DESCRIPTION
Address https://github.com/rancher/rancher/issues/17147#issuecomment-471712299

1. Add `list-answers` command to print current answers of a mcapp
```
$ rancher mcapp list-answers myapp
SCOPE                            QUESTION              ANSWER
Global                           mysqlDatabase         admin
Global                           mysqlPassword         abc000
Global                           mysqlUser             admin
Global                           persistence.enabled   false
Global                           service.port          3306
Global                           service.type          ClusterIP
Global                           defaultImage          true
All projects in cluster lawr-t   mysqlPassword         abc222
Project Default                  mysqlPassword         abc111
```
2. Add upgrade strategy options to install/upgrade
3. Error out on invalid version and improve checks
4. Wait for mcapp `active` state on install/upgrade/rollback/add-project and add `--timeout` option
5. Add `--rollback` option for upgrade to support rollback on failure