### PR TITLE
Change global DNS target in a straightforward way

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -27,5 +27,5 @@ github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0
 github.com/stretchr/testify v1.2.2
 
-github.com/rancher/norman fe50543a2e84d5c77ec8fa91f8fc082b67de7072
-github.com/rancher/types 3dad603a0f8c7ce2c74449fb8a4312fb3baa3176
+github.com/rancher/norman 457c15b94acae52afb5290aa315452c7621d452a
+github.com/rancher/types ee87bbdceacff5c566f901bdc57eec8330e7ed13

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_backup_config.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_backup_config.go
@@ -2,12 +2,14 @@ package client
 
 const (
 	BackupConfigType                = "backupConfig"
+	BackupConfigFieldEnabled        = "enabled"
 	BackupConfigFieldIntervalHours  = "intervalHours"
 	BackupConfigFieldRetention      = "retention"
 	BackupConfigFieldS3BackupConfig = "s3BackupConfig"
 )
 
 type BackupConfig struct {
+	Enabled        *bool           `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	IntervalHours  int64           `json:"intervalHours,omitempty" yaml:"intervalHours,omitempty"`
 	Retention      int64           `json:"retention,omitempty" yaml:"retention,omitempty"`
 	S3BackupConfig *S3BackupConfig `json:"s3BackupConfig,omitempty" yaml:"s3BackupConfig,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_alert_rule.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_alert_rule.go
@@ -15,6 +15,7 @@ const (
 	ClusterAlertRuleFieldGroupID               = "groupId"
 	ClusterAlertRuleFieldGroupIntervalSeconds  = "groupIntervalSeconds"
 	ClusterAlertRuleFieldGroupWaitSeconds      = "groupWaitSeconds"
+	ClusterAlertRuleFieldInherited             = "inherited"
 	ClusterAlertRuleFieldLabels                = "labels"
 	ClusterAlertRuleFieldMetricRule            = "metricRule"
 	ClusterAlertRuleFieldName                  = "name"
@@ -42,6 +43,7 @@ type ClusterAlertRule struct {
 	GroupID               string             `json:"groupId,omitempty" yaml:"groupId,omitempty"`
 	GroupIntervalSeconds  int64              `json:"groupIntervalSeconds,omitempty" yaml:"groupIntervalSeconds,omitempty"`
 	GroupWaitSeconds      int64              `json:"groupWaitSeconds,omitempty" yaml:"groupWaitSeconds,omitempty"`
+	Inherited             *bool              `json:"inherited,omitempty" yaml:"inherited,omitempty"`
 	Labels                map[string]string  `json:"labels,omitempty" yaml:"labels,omitempty"`
 	MetricRule            *MetricRule        `json:"metricRule,omitempty" yaml:"metricRule,omitempty"`
 	Name                  string             `json:"name,omitempty" yaml:"name,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_alert_rule_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_cluster_alert_rule_spec.go
@@ -8,6 +8,7 @@ const (
 	ClusterAlertRuleSpecFieldGroupID               = "groupId"
 	ClusterAlertRuleSpecFieldGroupIntervalSeconds  = "groupIntervalSeconds"
 	ClusterAlertRuleSpecFieldGroupWaitSeconds      = "groupWaitSeconds"
+	ClusterAlertRuleSpecFieldInherited             = "inherited"
 	ClusterAlertRuleSpecFieldMetricRule            = "metricRule"
 	ClusterAlertRuleSpecFieldNodeRule              = "nodeRule"
 	ClusterAlertRuleSpecFieldRepeatIntervalSeconds = "repeatIntervalSeconds"
@@ -22,6 +23,7 @@ type ClusterAlertRuleSpec struct {
 	GroupID               string             `json:"groupId,omitempty" yaml:"groupId,omitempty"`
 	GroupIntervalSeconds  int64              `json:"groupIntervalSeconds,omitempty" yaml:"groupIntervalSeconds,omitempty"`
 	GroupWaitSeconds      int64              `json:"groupWaitSeconds,omitempty" yaml:"groupWaitSeconds,omitempty"`
+	Inherited             *bool              `json:"inherited,omitempty" yaml:"inherited,omitempty"`
 	MetricRule            *MetricRule        `json:"metricRule,omitempty" yaml:"metricRule,omitempty"`
 	NodeRule              *NodeRule          `json:"nodeRule,omitempty" yaml:"nodeRule,omitempty"`
 	RepeatIntervalSeconds int64              `json:"repeatIntervalSeconds,omitempty" yaml:"repeatIntervalSeconds,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_etcd_backup.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_etcd_backup.go
@@ -13,6 +13,7 @@ const (
 	EtcdBackupFieldCreatorID            = "creatorId"
 	EtcdBackupFieldFilename             = "filename"
 	EtcdBackupFieldLabels               = "labels"
+	EtcdBackupFieldManual               = "manual"
 	EtcdBackupFieldName                 = "name"
 	EtcdBackupFieldNamespaceId          = "namespaceId"
 	EtcdBackupFieldOwnerReferences      = "ownerReferences"
@@ -33,6 +34,7 @@ type EtcdBackup struct {
 	CreatorID            string            `json:"creatorId,omitempty" yaml:"creatorId,omitempty"`
 	Filename             string            `json:"filename,omitempty" yaml:"filename,omitempty"`
 	Labels               map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Manual               bool              `json:"manual,omitempty" yaml:"manual,omitempty"`
 	Name                 string            `json:"name,omitempty" yaml:"name,omitempty"`
 	NamespaceId          string            `json:"namespaceId,omitempty" yaml:"namespaceId,omitempty"`
 	OwnerReferences      []OwnerReference  `json:"ownerReferences,omitempty" yaml:"ownerReferences,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_etcd_backup_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_etcd_backup_spec.go
@@ -5,10 +5,12 @@ const (
 	EtcdBackupSpecFieldBackupConfig = "backupConfig"
 	EtcdBackupSpecFieldClusterID    = "clusterId"
 	EtcdBackupSpecFieldFilename     = "filename"
+	EtcdBackupSpecFieldManual       = "manual"
 )
 
 type EtcdBackupSpec struct {
 	BackupConfig *BackupConfig `json:"backupConfig,omitempty" yaml:"backupConfig,omitempty"`
 	ClusterID    string        `json:"clusterId,omitempty" yaml:"clusterId,omitempty"`
 	Filename     string        `json:"filename,omitempty" yaml:"filename,omitempty"`
+	Manual       bool          `json:"manual,omitempty" yaml:"manual,omitempty"`
 }

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_alert_rule.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_alert_rule.go
@@ -13,6 +13,7 @@ const (
 	ProjectAlertRuleFieldGroupID               = "groupId"
 	ProjectAlertRuleFieldGroupIntervalSeconds  = "groupIntervalSeconds"
 	ProjectAlertRuleFieldGroupWaitSeconds      = "groupWaitSeconds"
+	ProjectAlertRuleFieldInherited             = "inherited"
 	ProjectAlertRuleFieldLabels                = "labels"
 	ProjectAlertRuleFieldMetricRule            = "metricRule"
 	ProjectAlertRuleFieldName                  = "name"
@@ -39,6 +40,7 @@ type ProjectAlertRule struct {
 	GroupID               string            `json:"groupId,omitempty" yaml:"groupId,omitempty"`
 	GroupIntervalSeconds  int64             `json:"groupIntervalSeconds,omitempty" yaml:"groupIntervalSeconds,omitempty"`
 	GroupWaitSeconds      int64             `json:"groupWaitSeconds,omitempty" yaml:"groupWaitSeconds,omitempty"`
+	Inherited             *bool             `json:"inherited,omitempty" yaml:"inherited,omitempty"`
 	Labels                map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	MetricRule            *MetricRule       `json:"metricRule,omitempty" yaml:"metricRule,omitempty"`
 	Name                  string            `json:"name,omitempty" yaml:"name,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_alert_rule_spec.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_project_alert_rule_spec.go
@@ -6,6 +6,7 @@ const (
 	ProjectAlertRuleSpecFieldGroupID               = "groupId"
 	ProjectAlertRuleSpecFieldGroupIntervalSeconds  = "groupIntervalSeconds"
 	ProjectAlertRuleSpecFieldGroupWaitSeconds      = "groupWaitSeconds"
+	ProjectAlertRuleSpecFieldInherited             = "inherited"
 	ProjectAlertRuleSpecFieldMetricRule            = "metricRule"
 	ProjectAlertRuleSpecFieldPodRule               = "podRule"
 	ProjectAlertRuleSpecFieldProjectID             = "projectId"
@@ -19,6 +20,7 @@ type ProjectAlertRuleSpec struct {
 	GroupID               string        `json:"groupId,omitempty" yaml:"groupId,omitempty"`
 	GroupIntervalSeconds  int64         `json:"groupIntervalSeconds,omitempty" yaml:"groupIntervalSeconds,omitempty"`
 	GroupWaitSeconds      int64         `json:"groupWaitSeconds,omitempty" yaml:"groupWaitSeconds,omitempty"`
+	Inherited             *bool         `json:"inherited,omitempty" yaml:"inherited,omitempty"`
 	MetricRule            *MetricRule   `json:"metricRule,omitempty" yaml:"metricRule,omitempty"`
 	PodRule               *PodRule      `json:"podRule,omitempty" yaml:"podRule,omitempty"`
 	ProjectID             string        `json:"projectId,omitempty" yaml:"projectId,omitempty"`

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_global_dnstargets_input.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_update_global_dnstargets_input.go
@@ -1,12 +1,10 @@
 package client
 
 const (
-	UpdateGlobalDNSTargetsInputType                   = "updateGlobalDNSTargetsInput"
-	UpdateGlobalDNSTargetsInputFieldMultiClusterAppID = "multiClusterAppId"
-	UpdateGlobalDNSTargetsInputFieldProjectIDs        = "projectIds"
+	UpdateGlobalDNSTargetsInputType            = "updateGlobalDNSTargetsInput"
+	UpdateGlobalDNSTargetsInputFieldProjectIDs = "projectIds"
 )
 
 type UpdateGlobalDNSTargetsInput struct {
-	MultiClusterAppID string   `json:"multiClusterAppId,omitempty" yaml:"multiClusterAppId,omitempty"`
-	ProjectIDs        []string `json:"projectIds,omitempty" yaml:"projectIds,omitempty"`
+	ProjectIDs []string `json:"projectIds,omitempty" yaml:"projectIds,omitempty"`
 }


### PR DESCRIPTION
Address https://github.com/rancher/rancher/issues/17982#issuecomment-472225106

Problem:
Cannot change globalDNS target to mcapp when it aims at projects, and vice versa

Solution:
Delete existing project target when mcapp target is set,
Delete existing mcapp target when try to add project target.