### PR TITLE
Fix project-scoped catalog app upgrade

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -453,14 +453,9 @@ func updateExternalIDVersion(externalID string, version string) (string, error) 
 		return "", err
 	}
 
-	q := u.Query()
-	q.Set("version", version)
-	// Need to unescape here to get the raw string for the externalId filter
-	catalogQuery, err := url.QueryUnescape(q.Encode())
-	if err != nil {
-		return "", err
-	}
-	return "catalog://?" + catalogQuery, nil
+	oldVersionQuery := fmt.Sprintf("version=%s", u.Query().Get("version"))
+	newVersionQuery := fmt.Sprintf("version=%s", version)
+	return strings.Replace(externalID, oldVersionQuery, newVersionQuery, 1), nil
 }
 
 func appRollback(ctx *cli.Context) error {

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -84,9 +84,13 @@ func TestGetExternalIDInVersion(t *testing.T) {
 
 	got, err := updateExternalIDVersion("catalog://?catalog=library&template=cert-manager&version=v0.5.2", "v1.2.3")
 	assert.Nil(err)
-	assert.Equal(got, "catalog://?catalog=library&template=cert-manager&version=v1.2.3")
+	assert.Equal("catalog://?catalog=library&template=cert-manager&version=v1.2.3", got)
 
-	got, err = updateExternalIDVersion("catalog://?catalog=p-826f4/pcatalog&template=mysql&version=0.3.8", "0.3.9")
+	got, err = updateExternalIDVersion("catalog://?catalog=c-29wkq/clusterscope&type=clusterCatalog&template=mysql&version=0.3.8", "0.3.9")
 	assert.Nil(err)
-	assert.Equal(got, "catalog://?catalog=p-826f4/pcatalog&template=mysql&version=0.3.9")
+	assert.Equal("catalog://?catalog=c-29wkq/clusterscope&type=clusterCatalog&template=mysql&version=0.3.9", got)
+
+	got, err = updateExternalIDVersion("catalog://?catalog=p-j9gfw/projectscope&type=projectCatalog&template=grafana&version=0.0.31", "0.0.30")
+	assert.Nil(err)
+	assert.Equal("catalog://?catalog=p-j9gfw/projectscope&type=projectCatalog&template=grafana&version=0.0.30", got)
 }


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/21253

Problem:
When upgrading a project scoped catalog app, the externalId is not constructed properly. Therefore, it results in a version-not-found error. The cause is that URL parsing does not preserve query orders, given that it turns to a map under the hood. It breaks since we introduced 'type' param to the externalId. 

For example, 
`catalog://?catalog=cid&type=projectCatalog&template=grafana&version=0.0.30` 
becomes 
`catalog://?catalog=cid&template=grafana&type=projectCatalog&version=0.0.30`. 
Therefore the externalId filter does not work.

Solution:
Change the url.Encode way to get externalId for a newer version