### PR TITLE
Allow ssh via external ip

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -20,15 +20,21 @@ import (
 )
 
 const sshDescription = `
-For any nodes created through Rancher using docker-machine, 
+For any nodes created through Rancher using docker-machine,
 you can SSH into the node. This is not supported for any custom nodes.
 
 Examples:
 	# SSH into a node by ID/name
 	$ rancher ssh nodeFoo
 
+	# SSH into a node by ID/name using the external IP address
+	$ rancher ssh -e nodeFoo
+
 	# SSH into a node by name but specify the username to use
-	$ rancher ssh -l user1 nodeFoo
+	$ rancher ssh -u user1 nodeFoo
+
+	# SSH into a node by specifying user and node using the @ syntax while adding a command to run
+	$ rancher ssh user1@nodeFoo env
 
 	# SSH into a node by specifying user and node using the @ syntax while adding a command to run
 	$ rancher ssh user1@nodeFoo env
@@ -36,42 +42,45 @@ Examples:
 
 func SSHCommand() cli.Command {
 	return cli.Command{
-		Name:            "ssh",
-		Usage:           "SSH into a node",
-		Description:     sshDescription,
-		ArgsUsage:       "[NODE_ID/NODE_NAME]",
-		Action:          nodeSSH,
-		UsageText:       "potato",
-		SkipFlagParsing: true,
+		Name:        "ssh",
+		Usage:       "SSH into a node",
+		Description: sshDescription,
+		Action:      nodeSSH,
+		ArgsUsage:   "[NODE_ID/NODE_NAME]",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "external,e",
+				Usage: "Use the external ip address",
+			},
+			cli.StringFlag{
+				Name:  "username,u",
+				Usage: "The username",
+			},
+		},
+		SkipFlagParsing: false,
 	}
 }
 
 func nodeSSH(ctx *cli.Context) error {
-	if ctx.NArg() == 0 {
-		return cli.ShowCommandHelp(ctx, "ssh")
-	}
 
 	args := ctx.Args()
 	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
 		return cli.ShowCommandHelp(ctx, "ssh")
 	}
 
-	// ssh nodeName or ssh -l user nodeName or ssh user@nodeName
-	var user string
-	var nodeName string
-	if strings.Contains(args[0], "@") {
-		pieces := strings.Split(args[0], "@")
-		user = pieces[0]
-		nodeName = pieces[1]
-		args = args[1:]
-	} else if args[0] == "-l" {
-		user = args[1]
-		nodeName = args[2]
-		args = args[3:]
-	} else {
-		nodeName = args[0]
-		args = args[1:]
+	if ctx.NArg() == 0 {
+		return cli.ShowCommandHelp(ctx, "ssh")
 	}
+
+	user := ctx.String("username")
+	nodeName := ctx.Args().First()
+
+	if strings.Contains(nodeName, "@") {
+		user = strings.Split(nodeName, "@")[0]
+		nodeName = strings.Split(nodeName, "@")[1]
+	}
+
+	args = args[1:]
 
 	c, err := GetClient(ctx)
 	if err != nil {
@@ -97,7 +106,12 @@ func nodeSSH(ctx *cli.Context) error {
 		return err
 	}
 
-	return processExitCode(callSSH(key, sshNode.IPAddress, user, args))
+	ipAddress := sshNode.IPAddress
+	if ctx.Bool("external") {
+		ipAddress = sshNode.ExternalIPAddress
+	}
+
+	return processExitCode(callSSH(key, ipAddress, user, args))
 }
 
 func callSSH(content []byte, ip string, user string, args []string) error {


### PR DESCRIPTION
This PR implements a change so that you may SSH to the external node IP with the rancher CLI

```
rancher -e node-name
```

It also changes the flag for specifying the user from -l to -u (which seems to make more sense)

All changes are actually from jeremyweber, and I found them through:
https://forums.rancher.com/t/rancher-cli-and-ssh/11107

But since he was not replying and since he never made a PR, and I'd still love to have this contributed to upstream, here is a PR.. 