### PR TITLE
Pass rancherVersion when fetching templates

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -191,6 +191,14 @@ func searchForMember(ctx *cli.Context, c *cliclient.MasterClient, name string) (
 	return &results.Data[selection], nil
 }
 
+func getRancherServerVersion(c *cliclient.MasterClient) (string, error) {
+	setting, err := c.ManagementClient.Setting.ByID("server-version")
+	if err != nil {
+		return "", err
+	}
+	return setting.Value, err
+}
+
 func loadAndVerifyCert(path string) (string, error) {
 	caCert, err := ioutil.ReadFile(path)
 	if nil != err {

--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -1098,8 +1098,16 @@ func outputMultiClusterAppVersions(ctx *cli.Context, c *cliclient.MasterClient, 
 		return err
 	}
 
+	ver, err := getRancherServerVersion(c)
+	if err != nil {
+		return err
+	}
+
+	filter := defaultListOpts(ctx)
+	filter.Filters["rancherVersion"] = ver
+
 	template := &managementClient.Template{}
-	if err := c.ManagementClient.Ops.DoGet(templateVersion.Links["template"], &types.ListOpts{}, template); err != nil {
+	if err := c.ManagementClient.Ops.DoGet(templateVersion.Links["template"], filter, template); err != nil {
 		return err
 	}
 	writer := NewTableWriter([][]string{


### PR DESCRIPTION
Problem:
Rancher supports enforcing apps versions but all app templates are shown
even if they are not compatable with the version of rancher running

Solution:
Add the rancherVersion filter when getting templates so only valid app
templates are shown.

This does not stop a user from passing a version that is not considered valid for their Rancher server, the API enforces version checking for all app actions. 

Issue: https://github.com/rancher/rancher/issues/21733