### PR TITLE
Check for cluster export action

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -462,6 +462,10 @@ func clusterExport(ctx *cli.Context) error {
 		return err
 	}
 
+	if _, ok := cluster.Actions["exportYaml"]; !ok {
+		return errors.New("cluster does not support being exported")
+	}
+
 	export, err := c.ManagementClient.Cluster.ActionExportYaml(cluster)
 	if err != nil {
 		return err


### PR DESCRIPTION
Problem:
Some clusters can not be exported which can cause a unfriendly error

Solution:
Validate a cluster has the export action before attempting the call

Issue: https://github.com/rancher/rancher/issues/21309