### PR TITLE
Use version links to determine app version to install

### DIFF
--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -649,12 +649,18 @@ func multiClusterAppTemplateInstall(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	template, err := c.ManagementClient.Template.ByID(resource.ID)
+
+	template, err := getFilteredTemplate(ctx, c, resource.ID)
 	if err != nil {
 		return err
 	}
 
-	templateVersionID := templateVersionIDFromVersionLink(template.VersionLinks[template.DefaultVersion])
+	latestVersion, err := getTemplateLatestVersion(template)
+	if err != nil {
+		return err
+	}
+
+	templateVersionID := templateVersionIDFromVersionLink(latestVersion)
 	userVersion := ctx.String("version")
 	if userVersion != "" {
 		if link, ok := template.VersionLinks[userVersion]; ok {


### PR DESCRIPTION
Problem:
defaultVersion on an app template does not take into account the rancher
server version so attempting to use that version to install an app can
cause errors

Solution:
Use a template filtered off the rancher server version to get the latest
version of the app to default to

https://github.com/rancher/rancher/issues/22127