### PR TITLE
Call yaml.Unmarshal on values/answers file using YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.trash-cache
 /.idea
 trash.lock
+/cli

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1078,13 +1078,13 @@ func processAnswers(
 	}
 
 	if ctx.String("values") != "" {
-		if err := getValuesFile(ctx.String("values"), answers); err != nil {
+		if err := parseValuesFile(ctx.String("values"), answers); err != nil {
 			return answers, err
 		}
 	}
 
 	if ctx.String("answers") != "" {
-		err := getAnswersFile(ctx.String("answers"), answers)
+		err := parseAnswersFile(ctx.String("answers"), answers)
 		if err != nil {
 			return answers, err
 		}
@@ -1108,18 +1108,11 @@ func processAnswers(
 	return answers, nil
 }
 
-func getAnswersFile(location string, answers map[string]string) error {
-	bytes, err := readFileReturnJSON(location)
+func parseAnswersFile(location string, answers map[string]string) error {
+	holder, err := parseFile(location)
 	if err != nil {
 		return err
 	}
-
-	holder := make(map[string]interface{})
-	err = json.Unmarshal(bytes, &holder)
-	if err != nil {
-		return err
-	}
-
 	for key, value := range holder {
 		switch value.(type) {
 		case nil:
@@ -1131,18 +1124,34 @@ func getAnswersFile(location string, answers map[string]string) error {
 	return nil
 }
 
-// getValuesFile reads a values file and parse it to answers in helm strvals format
-func getValuesFile(location string, answers map[string]string) error {
-	bytes, err := readFileReturnJSON(location)
+// parseValuesFile reads a values file and parses it to answers in helm strvals format
+func parseValuesFile(location string, answers map[string]string) error {
+	values, err := parseFile(location)
 	if err != nil {
-		return err
-	}
-	values := make(map[string]interface{})
-	if err := json.Unmarshal(bytes, &values); err != nil {
 		return err
 	}
 	valuesToAnswers(values, answers)
 	return nil
+}
+
+func parseFile(location string) (map[string]interface{}, error) {
+	bytes, err := ioutil.ReadFile(location)
+	if err != nil {
+		return nil, err
+	}
+
+	values := make(map[string]interface{})
+	if hasPrefix(bytes, []byte("{")) {
+		// this is the check that "readFileReturnJSON" uses to differentiate between JSON and YAML
+		if err := json.Unmarshal(bytes, &values); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := yaml.Unmarshal(bytes, &values); err != nil {
+			return nil, err
+		}
+	}
+	return values, nil
 }
 
 func valuesToAnswers(values map[string]interface{}, answers map[string]string) {


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/20704
We use json.Unmarshal for files using JSON format, and convert the
YAML format files to JSON first and call json.Unmarshal on them as well.
The yaml to json conversion led to unquoted numbers getting converted to
scientific notation. So this commit fixes it by calling yaml.Unmarshal
directly on file with yaml format instead of converting them to json.