### PR TITLE
Do a nil check on appRevision.Status

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -309,7 +309,9 @@ func appLs(ctx *cli.Context) error {
 				return err
 			}
 
-			appTemplateFiles = appRevision.Status.Files
+			if appRevision.Status != nil {
+				appTemplateFiles = appRevision.Status.Files
+			}
 		}
 
 		parsedInfo, err := parseTemplateInfo(appExternalID, appTemplateFiles)


### PR DESCRIPTION
Problem:
appRevision.Status can be nil which will cause a panic

Solution:
Validate the field is not nil before assigning internal values

https://github.com/rancher/rancher/issues/23963