### PR TITLE
Set answers to question defaults

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -431,7 +431,10 @@ func appUpgrade(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	answers, values, err := getAnswersAndValues(ctx, c, app.Answers, false)
+
+	answers := app.Answers
+	values := app.ValuesYaml
+	answers, values, err = processFileInputs(ctx, c, nil, answers, values, false)
 	if err != nil {
 		return err
 	}
@@ -628,8 +631,7 @@ func templateInstall(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-
-		answers, values, err := getAnswersAndValues(ctx, c, app.Answers, false)
+		answers, values, err := processFileInputs(ctx, c, nil, nil, "", false)
 		if err != nil {
 			return err
 		}
@@ -682,10 +684,11 @@ func templateInstall(ctx *cli.Context) error {
 		}
 
 		interactive := !ctx.Bool("no-prompt")
-		answers, values, err := getAnswersAndValues(ctx, c, app.Answers, interactive)
+		answers, values, err := processFileInputs(ctx, c, templateVersion, nil, "", interactive)
 		if err != nil {
 			return err
 		}
+
 		namespace := ctx.String("namespace")
 		if namespace == "" {
 			namespace = template.Name + "-" + RandomLetters(5)
@@ -1080,6 +1083,87 @@ func createNamespace(c *cliclient.MasterClient, n string) error {
 	return nil
 }
 
+func processFileInputs(
+	ctx *cli.Context,
+	c *cliclient.MasterClient,
+	tv *managementClient.TemplateVersion,
+	answers map[string]string,
+	values string,
+	interactive bool) (map[string]string, string, error) {
+	var err error
+	if ctx.String("answers") != "" && ctx.String("values") != "" {
+		return nil, "", fmt.Errorf("cannot process an answers file and a values file")
+	}
+	if len(answers) != 0 && values != "" && !hasPassedInFile(ctx.String("answers"), ctx.String("values")) {
+		answers, err = processAnswers(ctx, c, tv, answers, interactive)
+		if err != nil {
+			return answers, values, err
+		}
+		values, err = processValues(ctx, tv, values)
+		if err != nil {
+			return answers, values, err
+		}
+	} else if (len(answers) != 0 && !hasPassedInFile(ctx.String("answers"), ctx.String("values"))) || ctx.String("answers") != "" {
+		values = ""
+		answers, err = processAnswers(ctx, c, tv, answers, interactive)
+		if err != nil {
+			return answers, values, err
+		}
+	} else if values != "" && !hasPassedInFile(ctx.String("answers"), ctx.String("values")) || ctx.String("values") != "" {
+		answers = nil
+		values, err = processValues(ctx, tv, values)
+		if err != nil {
+			return answers, values, err
+		}
+	} else {
+		values = ""
+		answers, err = processAnswers(ctx, c, tv, answers, interactive)
+		if err != nil {
+			return answers, values, err
+		}
+	}
+	return answers, values, nil
+}
+
+func hasPassedInFile(answersFilePathString string, valuesFilePathString string) bool {
+	if answersFilePathString != "" || valuesFilePathString != "" {
+		return true
+	}
+	return false
+}
+
+// processValues creates a map of the values file and fills in missing answers with defaults
+func processValues(ctx *cli.Context, tv *managementClient.TemplateVersion, existingValues string) (string, error) {
+	answers := make(map[string]string)
+	if existingValues != "" {
+		//parse values into map to ensure previous values are considered on update
+		valuesMap, err := createValuesMap([]byte(existingValues))
+		if err != nil {
+			return existingValues, err
+		}
+		valuesToAnswers(valuesMap, answers)
+	}
+	// add default values if answers missing from map
+	err := fillInDefaultAnswers(tv, answers)
+	if err != nil {
+		return existingValues, err
+	}
+
+	if ctx.String("values") != "" {
+		// if values file passed in, overwrite defaults with new key value pair
+		if err := parseValuesFile(ctx.String("values"), answers); err != nil {
+			return existingValues, err
+		}
+	}
+
+	// change map back into string to be consistent with ui
+	existingValues, err = parseMapToYamlString(answers)
+	if err != nil {
+		return existingValues, err
+	}
+	return existingValues, nil
+}
+
 // processAnswers adds answers to given map, and prompts users to answers chart questions if interactive is true
 func processAnswers(
 	ctx *cli.Context,
@@ -1093,9 +1177,11 @@ func processAnswers(
 		answers = make(map[string]string)
 	}
 
-	err := parseAnswersFile(ctx.String("answers"), answers)
-	if err != nil {
-		return answers, err
+	if ctx.String("answers") != "" {
+		err := parseAnswersFile(ctx.String("answers"), answers)
+		if err != nil {
+			return answers, err
+		}
 	}
 
 	for _, answer := range ctx.StringSlice("set") {
@@ -1105,6 +1191,7 @@ func processAnswers(
 		}
 	}
 
+	// interactive occurs before adding defaults to ensure all questions are asked
 	if interactive {
 		// answers to questions will be added to map
 		err := askQuestions(tv, answers)
@@ -1112,8 +1199,22 @@ func processAnswers(
 			return answers, err
 		}
 	}
-
+	var err error
+	// add default answers to any remaining questions that have missing answers on install
+	err = fillInDefaultAnswers(tv, answers)
+	if err != nil {
+		return answers, err
+	}
 	return answers, nil
+}
+
+// parseMapToYamlString create yaml string from answers map
+func parseMapToYamlString(answerMap map[string]string) (string, error) {
+	yamlFileString, err := yaml.Marshal(answerMap)
+	if err != nil {
+		return "", err
+	}
+	return string(yamlFileString), nil
 }
 
 func parseAnswersFile(location string, answers map[string]string) error {
@@ -1132,12 +1233,25 @@ func parseAnswersFile(location string, answers map[string]string) error {
 	return nil
 }
 
+// parseValuesFile reads a values file and parses it to answers in helm strvals format
+func parseValuesFile(location string, answers map[string]string) error {
+	values, err := parseFile(location)
+	if err != nil {
+		return err
+	}
+	valuesToAnswers(values, answers)
+	return nil
+}
+
 func parseFile(location string) (map[string]interface{}, error) {
 	bytes, err := ioutil.ReadFile(location)
 	if err != nil {
 		return nil, err
 	}
+	return createValuesMap(bytes)
+}
 
+func createValuesMap(bytes []byte) (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 	if hasPrefix(bytes, []byte("{")) {
 		// this is the check that "readFileReturnJSON" uses to differentiate between JSON and YAML
@@ -1150,15 +1264,6 @@ func parseFile(location string) (map[string]interface{}, error) {
 		}
 	}
 	return values, nil
-}
-
-// parse values from values file in string format
-func parseFileToString(location string) (string, error) {
-	bytes, err := ioutil.ReadFile(location)
-	if err != nil {
-		return "", err
-	}
-	return string(bytes), nil
 }
 
 func valuesToAnswers(values map[string]interface{}, answers map[string]string) {
@@ -1198,7 +1303,6 @@ func askQuestions(tv *managementClient.TemplateVersion, answers map[string]strin
 	for {
 		attempts++
 		for _, question := range tv.Questions {
-			// only ask the question if there is not an answer and it passes the ShowIf check
 			if _, ok := answers[question.Variable]; !ok && checkShowIf(question.ShowIf, answers) {
 				asked = true
 				answers[question.Variable] = askQuestion(question)
@@ -1271,6 +1375,30 @@ func askSubQuestion(q managementClient.SubQuestion) string {
 	return answer
 }
 
+// fillInDefaultAnswers parses through questions and creates an answer map with default answers if missing from map
+func fillInDefaultAnswers(tv *managementClient.TemplateVersion, answers map[string]string) error {
+	if tv == nil {
+		return nil
+	}
+	for _, question := range tv.Questions {
+		if _, ok := answers[question.Variable]; !ok && checkShowIf(question.ShowIf, answers) {
+			answers[question.Variable] = question.Default
+			if checkShowSubquestionIf(question, answers) {
+				for _, subQuestion := range question.Subquestions {
+					// set the sub-question if the showIf check passes
+					if _, ok := answers[subQuestion.Variable]; !ok && checkShowIf(subQuestion.ShowIf, answers) {
+						answers[subQuestion.Variable] = question.Default
+					}
+				}
+			}
+		}
+	}
+	if answers == nil {
+		return errors.New("could not generate default answers")
+	}
+	return nil
+}
+
 // checkShowIf uses the ShowIf field to determine if a question should be asked
 // this field comes in the format <key>=<value> where key is a question id and value is the answer
 func checkShowIf(s string, answers map[string]string) bool {
@@ -1298,27 +1426,4 @@ func checkShowSubquestionIf(q managementClient.Question, answers map[string]stri
 		}
 	}
 	return false
-}
-
-// when using --answers flag, values should be empty to match UI behavior
-// when using --values flag, answers should be empty to match UI behavior
-// when using --answers and --values flag, both should be returned. UI only offers answers or values, not both
-func getAnswersAndValues(ctx *cli.Context, c *cliclient.MasterClient, currentAnswers map[string]string, interactive bool) (map[string]string, string, error) {
-	var err error
-	answers := make(map[string]string)
-	if ctx.String("answers") != "" {
-		answers, err = processAnswers(ctx, c, nil, currentAnswers, interactive)
-		if err != nil {
-			return nil, "", err
-		}
-	}
-
-	values := ""
-	if ctx.String("values") != "" {
-		values, err = parseFileToString(ctx.String("values"))
-		if err != nil {
-			return nil, "", err
-		}
-	}
-	return answers, values, err
 }

--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -518,7 +518,7 @@ func multiClusterAppUpgrade(ctx *cli.Context) error {
 
 	update := make(map[string]interface{})
 	answers := fromMultiClusterAppAnswers(app.Answers)
-	answers, err = processAnswers(ctx, c, nil, answers, false)
+	answers, _, err = processFileInputs(ctx, c, nil, answers, "", false)
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func multiClusterAppTemplateInstall(ctx *cli.Context) error {
 	}
 
 	interactive := !ctx.Bool("no-prompt")
-	answers, err := processAnswers(ctx, c, templateVersion, nil, interactive)
+	answers, _, err := processFileInputs(ctx, c, templateVersion, nil, "", interactive)
 	if err != nil {
 		return err
 	}
@@ -911,7 +911,7 @@ func getTargetInput(ctx *cli.Context, c *cliclient.MasterClient) (*managementCli
 		return nil, err
 	}
 
-	answers, err := processAnswers(ctx, c, nil, nil, false)
+	answers, _, err := processFileInputs(ctx, c, nil, nil, "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/multiclusterapp.go
+++ b/cmd/multiclusterapp.go
@@ -518,7 +518,7 @@ func multiClusterAppUpgrade(ctx *cli.Context) error {
 
 	update := make(map[string]interface{})
 	answers := fromMultiClusterAppAnswers(app.Answers)
-	answers, _, err = processFileInputs(ctx, c, nil, answers, "", false)
+	answers, err = processAnswerUpdates(ctx, answers)
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func multiClusterAppTemplateInstall(ctx *cli.Context) error {
 	}
 
 	interactive := !ctx.Bool("no-prompt")
-	answers, _, err := processFileInputs(ctx, c, templateVersion, nil, "", interactive)
+	answers, err := processAnswerInstall(ctx, templateVersion, nil, interactive)
 	if err != nil {
 		return err
 	}
@@ -911,7 +911,7 @@ func getTargetInput(ctx *cli.Context, c *cliclient.MasterClient) (*managementCli
 		return nil, err
 	}
 
-	answers, _, err := processFileInputs(ctx, c, nil, nil, "", false)
+	answers, err := processAnswerUpdates(ctx, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Problem**
On install, answers were only being generated if prompted for answers or when being passed in

**Solution**
Build answers with default question responses when --no-prompt is true

**Original PR** 
https://github.com/rancher/cli/pull/268

**How it was previously working**
when the no-prompt flag is used, it will bypass being prompted for questions

**How this PR is working** 
When the no-prompt flag is used, it will fill in the valuesYaml with the default answers to the questions without being prompted to answer the questions. By setting the defaults in the valuesYaml, it follows more closely the hierarchy of answers / values / values yaml for helm charts

**Issue**
rancher/rancher#25514