### PR TITLE
Incorrect value being used for subquestion default

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1377,7 +1377,7 @@ func fillInDefaultAnswers(tv *managementClient.TemplateVersion, answers map[stri
 				for _, subQuestion := range question.Subquestions {
 					// set the sub-question if the showIf check passes
 					if _, ok := answers[subQuestion.Variable]; !ok && checkShowIf(subQuestion.ShowIf, answers) {
-						answers[subQuestion.Variable] = question.Default
+						answers[subQuestion.Variable] = subQuestion.Default
 					}
 				}
 			}


### PR DESCRIPTION
**Problem**
question.default is being set to the answers for subquestion.variable so the incorrect answers are appearing for subquestion defaults

**Solution**
use subquestion.default for the answers to the subquestion.variable

**Issue**
https://github.com/rancher/rancher/issues/25514