### PR TITLE
remove print msg

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -147,8 +147,6 @@ func runCredential(ctx *cli.Context) error {
 		customPrint(fmt.Errorf("LoadToken: %v", err))
 	}
 	if cachedCred != nil {
-		customPrint(fmt.Sprintf("Using cached token, run 'rancher token delete %s' "+
-			"if there's an error", cachedCredName))
 		return json.NewEncoder(os.Stdout).Encode(cachedCred)
 	}
 


### PR DESCRIPTION
Don't want this to come up for each kubectl run, will document instead. Couldn't find a way to propagate this error up to kubectl client because the cached token is still present with CLI, it's just deleted from rancher - and it's the actual kubectl call which validates the token. 