### PR TITLE
add global config flag and store token with config

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -35,7 +36,10 @@ import (
 	"github.com/urfave/cli"
 )
 
-const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+const (
+	letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	cfgFile = "cli2.json"
+)
 
 var (
 	errNoURL = errors.New("RANCHER_URL environment or --Url is not set, run `login`")
@@ -229,10 +233,10 @@ func verifyCert(caCert []byte) (string, error) {
 }
 
 func loadConfig(ctx *cli.Context) (config.Config, error) {
+	// path will always be set by the global flag default
 	path := ctx.GlobalString("config")
-	if path == "" {
-		path = os.ExpandEnv("${HOME}/.rancher/cli2.json")
-	}
+	path = filepath.Join(path, cfgFile)
+
 	cf := config.Config{
 		Path:    path,
 		Servers: make(map[string]*config.ServerConfig),

--- a/config/config.go
+++ b/config/config.go
@@ -21,12 +21,13 @@ type Config struct {
 
 //ServerConfig holds the config for each server the user has setup
 type ServerConfig struct {
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
-	TokenKey  string `json:"tokenKey"`
-	URL       string `json:"url"`
-	Project   string `json:"project"`
-	CACerts   string `json:"cacert"`
+	AccessKey       string                     `json:"accessKey"`
+	SecretKey       string                     `json:"secretKey"`
+	TokenKey        string                     `json:"tokenKey"`
+	URL             string                     `json:"url"`
+	Project         string                     `json:"project"`
+	CACerts         string                     `json:"cacert"`
+	KubeCredentials map[string]*ExecCredential `json:"kubeCredentials"`
 }
 
 func (c Config) Write() error {
@@ -53,6 +54,10 @@ func (c Config) FocusedServer() *ServerConfig {
 
 func (c ServerConfig) FocusedCluster() string {
 	return strings.Split(c.Project, ":")[0]
+}
+
+func (c ServerConfig) KubeToken(key string) *ExecCredential {
+	return c.KubeCredentials[key]
 }
 
 func (c ServerConfig) EnvironmentURL() (string, error) {

--- a/config/kube_config.go
+++ b/config/kube_config.go
@@ -1,0 +1,65 @@
+package config
+
+import "time"
+
+// ExecCredential is used by exec-based plugins to communicate credentials to
+// HTTP transports. //v1beta1/types.go
+type ExecCredential struct {
+	TypeMeta `json:",inline"`
+
+	// Spec holds information passed to the plugin by the transport. This contains
+	// request and runtime specific information, such as if the session is interactive.
+	Spec ExecCredentialSpec `json:"spec,omitempty"`
+
+	// Status is filled in by the plugin and holds the credentials that the transport
+	// should use to contact the API.
+	// +optional
+	Status *ExecCredentialStatus `json:"status,omitempty"`
+}
+
+// ExecCredentialSpec holds request and runtime specific information provided by
+// the transport.
+type ExecCredentialSpec struct{}
+
+// ExecCredentialStatus holds credentials for the transport to use.
+// Token and ClientKeyData are sensitive fields. This data should only be
+// transmitted in-memory between client and exec plugin process. Exec plugin
+// itself should at least be protected via file permissions.
+type ExecCredentialStatus struct {
+	// ExpirationTimestamp indicates a time when the provided credentials expire.
+	// +optional
+	ExpirationTimestamp *Time `json:"expirationTimestamp,omitempty"`
+	// Token is a bearer token used by the client for request authentication.
+	Token string `json:"token,omitempty"`
+	// PEM-encoded client TLS certificates (including intermediates, if any).
+	ClientCertificateData string `json:"clientCertificateData,omitempty"`
+	// PEM-encoded private key for the above certificate.
+	ClientKeyData string `json:"clientKeyData,omitempty"`
+}
+
+// TypeMeta describes an individual object in an API response or request
+// with strings representing the type of the object and its API schema version.
+// Structures that are versioned or persisted should inline TypeMeta.
+type TypeMeta struct {
+	// Kind is a string value representing the REST resource this object represents.
+	// Servers may infer this from the endpoint the client submits requests to.
+	// Cannot be updated.
+	// In CamelCase.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +optional
+	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
+
+	// APIVersion defines the versioned schema of this representation of an object.
+	// Servers should convert recognized schemas to the latest internal value, and
+	// may reject unrecognized values.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
+}
+
+// Time is a wrapper around time.Time which supports correct
+// marshaling to YAML and JSON.  Wrappers are provided for many
+// of the factory methods that the time package offers.
+type Time struct {
+	time.Time `protobuf:"-"`
+}

--- a/main.go
+++ b/main.go
@@ -81,6 +81,12 @@ func mainErr() error {
 			Name:  "debug",
 			Usage: "Debug logging",
 		},
+		cli.StringFlag{
+			Name:   "config, c",
+			Usage:  "Path to rancher config",
+			EnvVar: "RANCHER_CONFIG_DIR",
+			Value:  os.ExpandEnv("${HOME}/.rancher"),
+		},
 	}
 	app.Commands = []cli.Command{
 		cmd.AppCommand(),


### PR DESCRIPTION
kubeconfig token will now be stored with the rest
of the rancher config rather than in the .cache
directory. The location of the config directory
can now be configured.