### PR TITLE
Remove explicit userID

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -222,9 +222,8 @@ func addProjectMemberRoles(ctx *cli.Context) error {
 
 	for _, role := range roles {
 		rtb := managementClient.ProjectRoleTemplateBinding{
-			ProjectID:       projectID,
-			RoleTemplateID:  role,
-			UserPrincipalID: member.ID,
+			ProjectID:      projectID,
+			RoleTemplateID: role,
 		}
 		if member.PrincipalType == "user" {
 			rtb.UserPrincipalID = member.ID


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/31430

Because UserPrincipalID was included when the rtb object is instantiated, if the member being added is a group then the API request has both a UserPrincipalID and a GroupPrincipalID which causes an error.

We don't need to set the UserPrincipalID when we instantiate rtb, we can just let the if/else clause set it.