### PR TITLE
Add c-m- provisioing v2 format to regex for context

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -532,8 +532,9 @@ func parseClusterAndProjectID(id string) (string, string, error) {
 	// Examples:
 	// c-qmpbm:p-mm62v
 	// c-qmpbm:project-mm62v
+	// c-m-j2s7m6lq:p-mm62v
 	// See https://github.com/rancher/rancher/issues/14400
-	if match, _ := regexp.MatchString("((local)|(c-[[:alnum:]]{5})):(p|project)-[[:alnum:]]{5}", id); match {
+	if match, _ := regexp.MatchString("((local)|(c-[[:alnum:]]{5})|(c-m-[[:alnum:]]{8})):(p|project)-[[:alnum:]]{5}", id); match {
 		parts := SplitOnColon(id)
 		return parts[0], parts[1], nil
 	}

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -26,6 +26,8 @@ func (s *CommonTestSuite) TestParseClusterAndProjectID(c *check.C) {
 	testParse(c, "cocal:p-12345", "", "", true)
 	testParse(c, "c-123:p-123", "", "", true)
 	testParse(c, "", "", "", true)
+	testParse(c, "c-m-12345678:p-12345", "c-m-12345678", "p-12345", false)
+	testParse(c, "c-m-123:p-12345", "", "", true)
 }
 
 func testParse(c *check.C, testID, expectedCluster, expectedProject string, errorExpected bool) {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -152,7 +152,7 @@ func getProjectContext(ctx *cli.Context, c *cliclient.MasterClient) (string, err
 		// Check if given context is in valid format
 		_, _, err := parseClusterAndProjectID(context)
 		if err != nil {
-			return "", fmt.Errorf("Unable to parse context (%s). Please provide context as local:p-xxxxx, c-xxxxx:p-xxxxx, or c-xxxxx:project-xxxxx", context)
+			return "", fmt.Errorf("Unable to parse context (%s). Please provide context as local:p-xxxxx, c-xxxxx:p-xxxxx, c-xxxxx:project-xxxxx, c-m-xxxxxxxx:p-xxxxx or c-m-xxxxxxxx:project-xxxxx", context)
 		}
 		// Check if context exists
 		_, err = Lookup(c, context, "project")


### PR DESCRIPTION
Adding new provisioning v2 format `c-m-` to regex when validating cluster-id:project-id to switch context. 

https://github.com/rancher/rancher/issues/34723

Note: I like to remove the regex as it is going to bite us back if the format changes in the future and if it serves no other important functionality. It already bit us on several issues when I search the history. https://github.com/rancher/rancher/issues/17647 https://github.com/rancher/rancher/issues/14400.
cc @dramich 