### PR TITLE
fix: default config file path on Windows

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -17,6 +17,7 @@ import (
 	url2 "net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -39,7 +40,7 @@ Example:
 	$ rancher token delete all
 `
 
-var deleteCommandUsage = fmt.Sprintf("Delete cached token used for kubectl login at [%s] \n %s", os.ExpandEnv("${HOME}/.rancher"), deleteExample)
+var deleteCommandUsage = fmt.Sprintf("Delete cached token used for kubectl login at [%s] \n %s", filepath.Join(os.ExpandEnv("${HOME}"), ".rancher"), deleteExample)
 
 type LoginInput struct {
 	server       string

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -32,7 +33,7 @@ Run '{{.Name}} COMMAND --help' for more information on a command.
 
 var CommandHelpTemplate = `{{.Usage}}
 {{if .Description}}{{.Description}}{{end}}
-Usage: 
+Usage:
 	{{.HelpName}} {{if .Flags}}[OPTIONS] {{end}}{{if ne "None" .ArgsUsage}}{{if ne "" .ArgsUsage}}{{.ArgsUsage}}{{else}}[arg...]{{end}}{{end}}
 
 {{if .Flags}}Options:{{range .Flags}}
@@ -85,7 +86,7 @@ func mainErr() error {
 			Name:   "config, c",
 			Usage:  "Path to rancher config",
 			EnvVar: "RANCHER_CONFIG_DIR",
-			Value:  os.ExpandEnv("${HOME}/.rancher"),
+			Value:  filepath.Join(os.ExpandEnv("${HOME}"), ".rancher"),
 		},
 	}
 	app.Commands = []cli.Command{


### PR DESCRIPTION
This fixes rancher/rancher#31967 (which was closed by the reporter, but is definitely still an issue). Basically, use `filepath.Join()` rather than assuming `/` is the path separator.