### PR TITLE
[DNM until 2.6.3 is out] Transform all keys to JSON format for RKE config values

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -30,6 +30,35 @@ func (s *CommonTestSuite) TestParseClusterAndProjectID(c *check.C) {
 	testParse(c, "c-m-123:p-12345", "", "", true)
 }
 
+func (s *CommonTestSuite) TestConvertSnakeCaseKeysToCamelCase(c *check.C) {
+	cases := []struct {
+		input   map[string]interface{}
+		renamed map[string]interface{}
+	}{
+		{
+			map[string]interface{}{"foo_bar": "hello"},
+			map[string]interface{}{"fooBar": "hello"},
+		},
+		{
+			map[string]interface{}{"fooBar": "hello"},
+			map[string]interface{}{"fooBar": "hello"},
+		},
+		{
+			map[string]interface{}{"foobar": "hello", "some_key": "valueUnmodified", "bar-baz": "bar-baz"},
+			map[string]interface{}{"foobar": "hello", "someKey": "valueUnmodified", "bar-baz": "bar-baz"},
+		},
+		{
+			map[string]interface{}{"foo_bar": "hello", "backup_config": map[string]interface{}{"hello_world": true}, "config_id": 123},
+			map[string]interface{}{"fooBar": "hello", "backupConfig": map[string]interface{}{"helloWorld": true}, "configId": 123},
+		},
+	}
+
+	for _, tc := range cases {
+		convertSnakeCaseKeysToCamelCase(tc.input)
+		c.Assert(tc.input, check.DeepEquals, tc.renamed)
+	}
+}
+
 func testParse(c *check.C, testID, expectedCluster, expectedProject string, errorExpected bool) {
 	actualCluster, actualProject, actualErr := parseClusterAndProjectID(testID)
 	c.Assert(actualCluster, check.Equals, expectedCluster)


### PR DESCRIPTION
Currently, the CLI does not honor most values in a passed in `rke-config` file. The CLI silently ignored it, and new clusters used default values.

This fixes it, so the CLI respects and applies the settings in `rancher_kubernetes_engine_config`.
The same is now true for top-level keys above it, like `docker_root_dir`.
Unfortunately, this cannot be a perfect solution. But it's better than what we have now.

The problem is that most values in `RancherKubernetesEngineConfig` are defined with struct tags for both JSON and YAML in camelCase.
https://github.com/rancher/rancher/blob/release/v2.6/pkg/client/generated/management/v3/zz_generated_rancher_kubernetes_engine_config.go

Changing the tags will be a breaking change. For proper deserialization, we must convert all keys to camelCase.
Note that we ignore kebab-case keys. Users themselves should ensure any relevant keys
(especially top-level keys in `services`, like `kube-api` or `kube-controller`) are camelCase or snake-case in cluster config.
Otherwise, they will be ignored on deserialization, and defaults settings will be used. And some settings in `kube-api`, for example, are expected to be in kebab-case.

Our RKE docs, unfortunately, use kebab-case for some examples.

This should also fix the `import` flag. It would not do anything previously and create a default cluster. Now it just defers to the import command handler.

I would love to write an end-to-end test for this workflow: supply an RKE config file, compare resultant cluster configuration.
But we currently have no testing framework in place for such things in the CLI repository, since every such workflow makes a real API request to a live cluster.
