### PR TITLE
Escape quotes in username, password, responseType before sending auth request

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -348,7 +348,7 @@ func basicAuth(input *LoginInput, tlsConfig *tls.Config) (managementClient.Token
 		responseType = fmt.Sprintf("%s_%s", responseType, input.clusterID)
 	}
 
-	body := fmt.Sprintf(`{"responseType":"%s", "username":"%s", "password":"%s"}`, responseType, username, password)
+	body := fmt.Sprintf(`{"responseType":%q, "username":%q, "password":%q}`, responseType, username, password)
 
 	url := fmt.Sprintf("%s/v3-public/%ss/%s?action=login", input.server, input.authProvider,
 		strings.ToLower(strings.Replace(input.authProvider, "Provider", "", 1)))


### PR DESCRIPTION
This will allow quotes to be used as characters in usernames and passwords because the CLI will now escape them before setting the payload for an auth request.
