### PR TITLE
Implement drone-plugin-fossa

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -272,3 +272,19 @@ volumes:
 - name: socket
   host:
     path: /var/run/docker.sock
+
+---
+
+kind: pipeline
+name: fossa
+
+steps:
+- name: fossa
+  image: rancher/drone-fossa:latest
+  settings:
+    api_key:
+      from_secret: FOSSA_API_KEY
+  when:
+    instance:
+      - drone-publish.rancher.io
+


### PR DESCRIPTION
By default, this plugin will run the analyze command per the generic CI documentation for FOSSA.