### PR TITLE
Fix Incorrect Providers 

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -675,13 +675,26 @@ func getClusterByID(
 func getClusterProvider(cluster managementClient.Cluster) string {
 	switch cluster.Driver {
 	case "imported":
-		return "Imported"
+		switch cluster.Provider {
+		case "rke2":
+			return "RKE2"
+		case "k3s":
+			return "K3S"
+		default:
+			return "Imported"
+		}
+	case "k3s":
+		return "K3S"
+	case "rke2":
+		return "RKE2"
 	case "rancherKubernetesEngine":
 		return "Rancher Kubernetes Engine"
-	case "azureKubernetesService":
-		return "Azure Container Service"
-	case "googleKubernetesEngine":
+	case "azureKubernetesService", "AKS":
+		return "Azure Kubernetes Service"
+	case "googleKubernetesEngine", "GKE":
 		return "Google Kubernetes Engine"
+	case "EKS":
+		return "Elastic Kubernetes Service"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37554

Problem:
Incorrect Provider is seen for clusters using Rancher CLI:  RKE2 node driver cluster is seen as Imported and local cluster is seen as Unknown

Solutions:
fix the logic for determining the provider of a cluster.

Tests:
compile and run the cli and see the following now:
```
CURRENT   ID             STATE          NAME            PROVIDER                     NODES     CPU       RAM            PODS
*         c-4rnq9        active         jiaqi-eks2      Elastic Kubernetes Service   2         0/3.86    0/6.50 GB      0/34
          c-lfr6c        active         test-c1         Rancher Kubernetes Engine    1         0/2       0/3.74 GB      0/110
          c-m-27k7trsj   active         k3s-custom      K3S                          1         0/4       0/7.78 GB      0/110
          c-m-k7zbdshc   active         rke2-custome    RKE2                         1         0/4       0/7.78 GB      0/110
          c-m-wt5jtxbq   active         rke2-cluster1   RKE2                         1         0/2       0/3.80 GB      0/110
          c-wwpnq        provisioning   new-1           Rancher Kubernetes Engine    0         0/0       0/0 GB         0/0
          local          active         local           K3S                          1         0.10/4    0.07/7.78 GB   1/110
```