### PR TITLE
Improve clusters create description

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -59,7 +59,7 @@ func ClusterCommand() cli.Command {
 			{
 				Name:        "create",
 				Usage:       "Creates a new empty cluster",
-				Description: "Creates a new empty cluster",
+				Description: "Create a new custom cluster with desired configuration",
 				ArgsUsage:   "[NEWCLUSTERNAME...]",
 				Action:      clusterCreate,
 				Flags: []cli.Flag{


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37550
 
# Problem
When running `rancher-cli clusters create -h` the description and usage are the same 

# Solution
Improve the `rancher-cli clusters create` description to be more informative so that it is different than the usage.
 
# Testing
run `rancher-cli clusters create -h` and observe the new description