### PR TITLE
Display message when no servers are available

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -83,6 +83,10 @@ func serverDelete(ctx *cli.Context) error {
 		return err
 	}
 
+	if err := validateServersConfig(cf); err != nil {
+		return err
+	}
+
 	var serverName string
 	if ctx.NArg() == 1 {
 		serverName = ctx.Args().First()
@@ -114,6 +118,10 @@ func serverLs(ctx *cli.Context) error {
 		return err
 	}
 
+	if err := validateServersConfig(cf); err != nil {
+		return err
+	}
+
 	writer := NewTableWriter([][]string{
 		{"CURRENT", "Current"},
 		{"NAME", "Name"},
@@ -141,6 +149,10 @@ func serverLs(ctx *cli.Context) error {
 func serverSwitch(ctx *cli.Context) error {
 	cf, err := loadConfig(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := validateServersConfig(cf); err != nil {
 		return err
 	}
 
@@ -237,4 +249,11 @@ func getServerNames(cf config.Config) []string {
 	}
 	sort.Strings(serverNames)
 	return serverNames
+}
+
+func validateServersConfig(cnf config.Config) error {
+	if len(cnf.Servers) == 0 {
+		return errors.New("no servers are currently configured")
+	}
+	return nil
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37545

# Problem
When running `rancher-cli servers ls`, `rancher-cli servers delete` or `rancher-cli servers switch` when there are no servers configured, the cli will still prompt the user to select a server 

# Solution
Check if any servers exist within the configuration before prompting the user. If no servers are stored in the configuration, print a message to the user and do not prompt for further input. 

# Testing
delete the  `cli2.json` file to clear out any server configurations 
Run `rancher-cli servers ls` and observe that it does not prompt you for input 
Run `rancher-cli servers delete` and observe that it does not prompt you for input 
Run `rancher-cli servers switch` and observe that it does not prompt you for input 