### PR TITLE
Fix index out of bounds when installing hidden chart

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1034,6 +1034,9 @@ func getFilteredTemplate(ctx *cli.Context, c *cliclient.MasterClient, templateID
 
 // getTemplateLatestVersion returns the newest version of the template
 func getTemplateLatestVersion(template *managementClient.Template) (string, error) {
+	if len(template.VersionLinks) == 0 {
+		return "", errors.New("no versions found for this template (the chart you are trying to install may be intentionally hidden or deprecated for your Rancher version)")
+	}
 	sorted, err := sortTemplateVersions(template)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36332

Problem:
Charts in the old Rancher catalog are deprecated and hidden from the user. When you attempt to install any of them the Rancher cli tries to find the latest version of the chart and panics with an index out of bounds.

Solution:
This PR adds a conditional to recover from the panic gracefully, and provide an error with a description of the problem. Note this is an edge case and will most likely only be seen by users with the legacy flag enabled trying to use deprecated charts.
