### PR TITLE
fix snake case keys not renamed when jsonobject's type is array

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -573,8 +573,15 @@ func renameKeys(input map[string]interface{}, f func(string) string) {
 		delete(input, k)
 		newKey := f(k)
 		input[newKey] = v
-		if innerMap, ok := v.(map[string]interface{}); ok {
-			renameKeys(innerMap, f)
+		switch innerValue := v.(type) {
+		case map[string]interface{}:
+			renameKeys(innerValue, f)
+		case []interface{}:
+			for _, iv := range innerValue {
+				if innerMap, ok := iv.(map[string]interface{}); ok {
+					renameKeys(innerMap, f)
+				}
+			}
 		}
 	}
 }

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -51,6 +51,10 @@ func (s *CommonTestSuite) TestConvertSnakeCaseKeysToCamelCase(c *check.C) {
 			map[string]interface{}{"foo_bar": "hello", "backup_config": map[string]interface{}{"hello_world": true}, "config_id": 123},
 			map[string]interface{}{"fooBar": "hello", "backupConfig": map[string]interface{}{"helloWorld": true}, "configId": 123},
 		},
+		{
+			map[string]interface{}{"foo_bar": "hello", "some_array": []interface{}{map[string]interface{}{"some_key": "valueUnmodified"}}, "backup_config": map[string]interface{}{"hello_world": true}},
+			map[string]interface{}{"fooBar": "hello", "someArray": []interface{}{map[string]interface{}{"someKey": "valueUnmodified"}}, "backupConfig": map[string]interface{}{"helloWorld": true}},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This is a small improvement of the PR #310.

Try to fix snake to camel conversion issue in `rke-config` file when executing the `rancher clusters create --rke-config cluster.yml` command.

**Example:**

Execute the create cluster command with the following `rke-config` file:

```yaml
rancher_kubernetes_engine_config:
  dns:
    tolerations:
      - key: node.kubernetes.io/unreachable
        toleration_seconds: 300
      - key: node.kubernetes.io/not-ready
        tolerationSeconds: 300 # use camel case for workaround
```

Rancher server will receive the following json data:

```json
{
  "rancherKubernetesEngineConfig": {
    "dns": {
      "tolerations": [
        {
          "key": "node.kubernetes.io/unreachable",
          "toleration_seconds": 300
        },
        {
          "key": "node.kubernetes.io/not-ready",
          "tolerationSeconds": 300
        }
      ]
    }
  }
}
```

The Rancher server does not use snake-case in cluster config, so the `toleration_seconds` of the first set will be ignored.

After this PR get merged, Rancher server will receive the correct data:

```json
{
  "rancherKubernetesEngineConfig": {
    "dns": {
      "tolerations": [
        {
          "key": "node.kubernetes.io/unreachable",
          "tolerationSeconds": 300
        },
        {
          "key": "node.kubernetes.io/not-ready",
          "tolerationSeconds": 300
        }
      ]
    }
  }
}
```