### PR TITLE
Add taint flag to cluster add-node command

### DIFF
--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -130,6 +130,10 @@ func ClusterCommand() cli.Command {
 						Name:  "worker",
 						Usage: "Use node as a worker",
 					},
+					cli.StringSliceFlag{
+						Name:  "taint",
+						Usage: "Taint to apply to a node in the format [name]=[value:effect]",
+					},
 					quietFlag,
 				},
 			},
@@ -386,6 +390,12 @@ func clusterAddNode(ctx *cli.Context) error {
 	if labels := ctx.StringSlice("label"); labels != nil {
 		for _, label := range labels {
 			command = command + fmt.Sprintf(" --label %v", label)
+		}
+	}
+
+	if taints := ctx.StringSlice("taint"); taints != nil {
+		for _, taint := range taints {
+			command = command + fmt.Sprintf(" --taint %v", taint)
 		}
 	}
 


### PR DESCRIPTION
On Rancher's cluster registration page, the one that shows you de node registration command, you have the options (Step 2) to add both node labels and taints. However, the cli `cluster add-node` command, which also prints the node registration command, only has a flag for node labels.

This Pull Request adds a flag for node taints to the `cluster add-node` command, printing a node registration command accordingly.

```
rancher cluster add-node --worker --taint key=value:NoSchedule
sudo docker run -d --privileged --restart=unless-stopped --net=host -v /etc/kubernetes:/etc/kubernetes -v /var/run:/var/run  rancher/rancher-agent:v2.6.5 --server https://redacted --token redacted --ca-checksum redacted --worker --taint key=value:NoSchedule
```