### PR TITLE
Enable cli completion

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func mainErr() error {
 	app.Version = VERSION
 	app.Author = "Rancher Labs, Inc."
 	app.Email = ""
+	app.EnableBashCompletion = true
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "debug",


### PR DESCRIPTION
Enables the  `--generate-bash-completion` flag provided by `urfave/cli` 

Documentation can be found at https://github.com/urfave/cli/blob/main/docs/v2/examples/bash-completions.md


Completion scripts can be found at https://github.com/urfave/cli/tree/main/autocomplete