### PR TITLE
Config store helper

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -263,7 +263,7 @@ func verifyCert(caCert []byte) (string, error) {
 
 func loadConfig(ctx *cli.Context) (config.Config, error) {
 	switch ctx.GlobalString("config-helper") {
-	case "build-in":
+	case "built-in":
 		return loadConfigNative(ctx)
 	default:
 		// allow loading of rancher config by triggering an

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ type ServerConfig struct {
 
 func (c Config) Write() error {
 	switch c.Helper {
-	case "build-in":
+	case "built-in":
 		return c.writeNative()
 	default:
 		// if rancher config was loaded by external helper

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func mainErr() error {
 			Name:   "config-helper",
 			Usage:  "Helper executable to load/store config",
 			EnvVar: "RANCHER_CONFIG_HELPER",
-			Value:  os.ExpandEnv("build-in"),
+			Value:  os.ExpandEnv("built-in"),
 		},
 	}
 	app.Commands = []cli.Command{

--- a/main.go
+++ b/main.go
@@ -86,6 +86,12 @@ func mainErr() error {
 			EnvVar: "RANCHER_CONFIG_DIR",
 			Value:  os.ExpandEnv("${HOME}/.rancher"),
 		},
+		cli.StringFlag{
+			Name:   "config-helper",
+			Usage:  "Helper executable to load/store config",
+			EnvVar: "RANCHER_CONFIG_HELPER",
+			Value:  os.ExpandEnv("build-in"),
+		},
 	}
 	app.Commands = []cli.Command{
 		cmd.AppCommand(),


### PR DESCRIPTION
This MR allows to define a local executable via the flag `--config-helper` or EnvVar `RANCHER_CONFIG_HELPER` to store the rancher config.

The methods to `load` and `write` the config are intercepted and by default keep the existing method of storing the config as file on the filesystem. (~/.rancher/cli2.json)
If the flag `--config-helper` is set to a other values than `built-in`, the method invokes a call to the defined executable with the argument `get` to load the config and `store` to persist the config.

An example config-helper could look like this:

rancher-helper
```
#!/bin/zsh

case "$1" in
    get)   gopass show -o -y rancher-config ;;
    store) echo $2 | gopass insert -f rancher-config ;;
esac
```

The motivation for this MR is to allow a secure storage of the credentials found in the rancher config.
