### PR TITLE
doc: update cli command documentation

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -46,7 +46,7 @@ func NamespaceCommand() cli.Command {
 				Name:        "create",
 				Usage:       "Create a namespace",
 				Description: "\nCreates a namespace in the current cluster.",
-				ArgsUsage:   "[NEWPROJECTNAME...]",
+				ArgsUsage:   "[NEWNAMESPACENAME...]",
 				Action:      namespaceCreate,
 				Flags: []cli.Flag{
 					cli.StringFlag{


### PR DESCRIPTION
The `ranchercli namespace create` command prints a help message that references `[NEWPROJECTNAME...]`.

I propose changing that to the more fitting `[NEWNAMESPACENAME...]`