### PR TITLE
Allow insecure server connections

### DIFF
--- a/cliclient/cliclient.go
+++ b/cliclient/cliclient.go
@@ -185,6 +185,7 @@ func createClientOpts(config *config.ServerConfig) *clientbase.ClientOpts {
 		AccessKey: config.AccessKey,
 		SecretKey: config.SecretKey,
 		CACerts:   config.CACerts,
+		Insecure:  config.Insecure,
 	}
 	return options
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -61,6 +61,10 @@ func LoginCommand() cli.Command {
 				Name:  "skip-verify",
 				Usage: "Skip verification of the CACerts presented by the Server",
 			},
+			cli.BoolFlag{
+				Name:  "insecure",
+				Usage: "Allow insecure server connections",
+			},
 		},
 	}
 }
@@ -80,7 +84,9 @@ func loginSetup(ctx *cli.Context) error {
 		serverName = "rancherDefault"
 	}
 
-	serverConfig := &config.ServerConfig{}
+	serverConfig := &config.ServerConfig{
+		Insecure: ctx.Bool("insecure"),
+	}
 
 	// Validate the url and drop the path
 	u, err := url.ParseRequestURI(ctx.Args().First())

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type ServerConfig struct {
 	CACerts         string                     `json:"cacert"`
 	KubeCredentials map[string]*ExecCredential `json:"kubeCredentials"`
 	KubeConfigs     map[string]*api.Config     `json:"kubeConfigs"`
+	Insecure        bool                       `json:"insecure"`
 }
 
 func (c Config) Write() error {


### PR DESCRIPTION
Now, add a `--insecure` option to skip the SSL certificate validation.

When the SSL certificate used by the rancher server is invalid, it will prompt `FATA[0000] Get "https://rancher.example.com/v3": x509: “dynamic” certificate is not trusted`.
