### PR TITLE
Add azureADProvider as supported AuthProvider

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -70,7 +70,6 @@ var supportedAuthProviders = map[string]bool{
 	"activeDirectoryProvider": true,
 	"azureADProvider":         true,
 
-
 	// all saml providers
 	"pingProvider":       true,
 	"adfsProvider":       true,

--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -68,6 +68,8 @@ var supportedAuthProviders = map[string]bool{
 	"freeIpaProvider":         true,
 	"openLdapProvider":        true,
 	"activeDirectoryProvider": true,
+	"azureADProvider":         true,
+
 
 	// all saml providers
 	"pingProvider":       true,


### PR DESCRIPTION
Use Case:
Allow rancher cli (and kubectl by proxy) to request a token from Rancher Management Server using azureADProvider. Currently falls back to localProvider since azureADProvider is not on the list of supportedAuthProviders.

Would still need to be tested to verify functionality.

