### PR TITLE
[2.7] Add missing packages after moving Dapper image to BCI

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/golang:1.19
 
-RUN zypper -n install docker
+RUN zypper -n install docker rsync xz zip
 
 ENV GOLANGCI_LINT v1.53.3
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "$GOLANGCI_LINT"


### PR DESCRIPTION
Add missing packages after moving Dapper image to BCI in https://github.com/rancher/cli/pull/337.