### PR TITLE
Create config with 0600 permissions by default

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -259,27 +258,15 @@ func verifyCert(caCert []byte) (string, error) {
 	return string(caCert), nil
 }
 
-func loadConfig(ctx *cli.Context) (config.Config, error) {
+func GetConfigPath(ctx *cli.Context) string {
 	// path will always be set by the global flag default
 	path := ctx.GlobalString("config")
-	path = filepath.Join(path, cfgFile)
+	return filepath.Join(path, cfgFile)
+}
 
-	cf := config.Config{
-		Path:    path,
-		Servers: make(map[string]*config.ServerConfig),
-	}
-
-	content, err := ioutil.ReadFile(path)
-	if os.IsNotExist(err) {
-		return cf, nil
-	} else if err != nil {
-		return cf, err
-	}
-
-	err = json.Unmarshal(content, &cf)
-	cf.Path = path
-
-	return cf, err
+func loadConfig(ctx *cli.Context) (config.Config, error) {
+	path := GetConfigPath(ctx)
+	return config.LoadFromPath(path)
 }
 
 func lookupConfig(ctx *cli.Context) (*config.ServerConfig, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,6 +28,109 @@ const (
 	invalidFile = `invalid config file`
 )
 
+func Test_GetFilePermissionWarnings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		mode             os.FileMode
+		expectedWarnings int
+	}{
+		{
+			name:             "neither group-readable nor world-readable",
+			mode:             os.FileMode(0600),
+			expectedWarnings: 0,
+		},
+		{
+			name:             "group-readable and world-readable",
+			mode:             os.FileMode(0644),
+			expectedWarnings: 2,
+		},
+		{
+			name:             "group-readable",
+			mode:             os.FileMode(0640),
+			expectedWarnings: 1,
+		},
+		{
+			name:             "world-readable",
+			mode:             os.FileMode(0604),
+			expectedWarnings: 1,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert := assert.New(t)
+
+			dir, err := os.MkdirTemp("", "rancher-cli-test-*")
+			assert.NoError(err)
+			defer os.RemoveAll(dir)
+
+			path := filepath.Join(dir, "cli2.json")
+			err = os.WriteFile(path, []byte(validFile), tt.mode)
+			assert.NoError(err)
+
+			warnings, err := GetFilePermissionWarnings(path)
+			assert.NoError(err)
+			assert.Len(warnings, tt.expectedWarnings)
+		})
+	}
+}
+
+func Test_Permission(t *testing.T) {
+	t.Parallel()
+
+	// New config files should have 0600 permissions
+	t.Run("new config file", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+
+		dir, err := os.MkdirTemp("", "rancher-cli-test-*")
+		assert.NoError(err)
+		defer os.RemoveAll(dir)
+
+		path := filepath.Join(dir, "cli2.json")
+		conf, err := LoadFromPath(path)
+		assert.NoError(err)
+
+		err = conf.Write()
+		assert.NoError(err)
+
+		info, err := os.Stat(path)
+		assert.NoError(err)
+		assert.Equal(os.FileMode(0600), info.Mode())
+
+		// make sure new file doesn't create permission warnings
+		warnings, err := GetFilePermissionWarnings(path)
+		assert.NoError(err)
+		assert.Len(warnings, 0)
+	})
+	// Already existing config files should keep their current permissions
+	t.Run("existing config file", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+
+		dir, err := os.MkdirTemp("", "rancher-cli-test-*")
+		assert.NoError(err)
+		defer os.RemoveAll(dir)
+
+		path := filepath.Join(dir, "cli2.json")
+		err = os.WriteFile(path, []byte(validFile), 0700)
+		assert.NoError(err)
+
+		conf, err := LoadFromPath(path)
+		assert.NoError(err)
+
+		err = conf.Write()
+		assert.NoError(err)
+
+		info, err := os.Stat(path)
+		assert.NoError(err)
+		assert.Equal(os.FileMode(0700), info.Mode())
+	})
+}
+
 func Test_LoadFromPath(t *testing.T) {
 	t.Parallel()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	validFile = `
+{
+  "Servers": {
+    "rancherDefault": {
+      "accessKey": "the-access-key",
+      "secretKey": "the-secret-key",
+      "tokenKey": "the-token-key",
+      "url": "https://example.com",
+      "project": "cluster-id:project-id",
+      "cacert": "",
+      "kubeCredentials": null,
+      "kubeConfigs": null
+    }
+  },
+  "CurrentServer": "rancherDefault"
+}`
+	invalidFile = `invalid config file`
+)
+
+func Test_LoadFromPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		content      string
+		expectedConf Config
+		expectedErr  bool
+	}{
+		{
+			name:    "valid config",
+			content: validFile,
+			expectedConf: Config{
+				Servers: map[string]*ServerConfig{
+					"rancherDefault": {
+						AccessKey: "the-access-key",
+						SecretKey: "the-secret-key",
+						TokenKey:  "the-token-key",
+						URL:       "https://example.com",
+						Project:   "cluster-id:project-id",
+						CACerts:   "",
+					},
+				},
+				CurrentServer: "rancherDefault",
+			},
+		},
+		{
+			name:    "invalid config",
+			content: invalidFile,
+			expectedConf: Config{
+				Servers: map[string]*ServerConfig{},
+			},
+			expectedErr: true,
+		},
+		{
+			name:    "non existing file",
+			content: "",
+			expectedConf: Config{
+				Servers:       map[string]*ServerConfig{},
+				CurrentServer: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert := assert.New(t)
+
+			dir, err := os.MkdirTemp("", "rancher-cli-test-*")
+			assert.NoError(err)
+			defer os.RemoveAll(dir)
+
+			path := filepath.Join(dir, "cli2.json")
+			// make sure the path points to the temp dir created in the test
+			tt.expectedConf.Path = path
+
+			if tt.content != "" {
+				err = os.WriteFile(path, []byte(tt.content), 0600)
+				assert.NoError(err)
+			}
+
+			conf, err := LoadFromPath(path)
+			if tt.expectedErr {
+				assert.Error(err)
+				// We kept the old behavior of returning a valid config even in
+				// case of an error so we assert it here. If you change this
+				// behavior, make sure there aren't any regressions.
+				assert.Equal(tt.expectedConf, conf)
+				return
+			}
+
+			assert.NoError(err)
+			assert.Equal(tt.expectedConf, conf)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rancher/cli/cmd"
+	"github.com/rancher/cli/config"
 	rancherprompt "github.com/rancher/cli/rancher_prompt"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -70,6 +71,17 @@ func mainErr() error {
 		if ctx.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
+
+		path := cmd.GetConfigPath(ctx)
+		warnings, err := config.GetFilePermissionWarnings(path)
+		if err != nil {
+			// We don't want to block the execution of the CLI in that case
+			logrus.Errorf("Unable to verify config file permission: %s. Continuing.", err)
+		}
+		for _, warning := range warnings {
+			logrus.Warning(warning)
+		}
+
 		return nil
 	}
 	app.Version = VERSION


### PR DESCRIPTION
Issue: rancher/rancher#42838

# Problem

The default permissions was `0644`  which is not the most secure default.

# Solution

Change the default permission to `0600`. Keep same permissions for config files that already exists. Warn the user if config file is either group-readable or world-readable.

# Summary of changes

First commit moves the bulk of the loading code to `config/` module, it seems more appropriate. I also added some tests to make sure I didn't totally break anything with the move.

Second commit does the following:
- Changed the default file creation to `0600` permissions. As discussed, already existing files won't have their permissions changed, this only affects new files.
- A warning is emitted if the file is either group-readable or world-readable. The message was heavily inspired by the kubectl one. I've made it so that the warning is only written once per CLI invocation, since some commands read the config multiple times.

The result is:

```
$ chmod o+r ~/.rancher/cli2.json
$ ./bin/rancher login --token $token https://example.com
WARN[0000] Rancher configuration file /home/tlebreux/.rancher/cli2.json is world-readable. This is insecure. 
INFO[0000] Saving config to /home/tlebreux/.rancher/cli2.json

$ chmod g+r ~/.rancher/cli2.json 
$ ./bin/rancher login --token $token https://example.com
WARN[0000] Rancher configuration file /home/tlebreux/.rancher/cli2.json is group-readable. This is insecure. 
WARN[0000] Rancher configuration file /home/tlebreux/.rancher/cli2.json is world-readable. This is insecure. 
INFO[0000] Saving config to /home/tlebreux/.rancher/cli2.json  

$ chmod 0600 ~/.rancher/cli2.json
$ ./bin/rancher login --token $token https://example.com
INFO[0000] Saving config to /home/tlebreux/.rancher/cli2.json 
```

# Checklist

I have tested done some manual tests:
- Made sure that existing file don't have their permission changed
- All permuttations of g+r, o+r emit the appropriate warnings
- Some commands still work (eg: login, nodes)
- Verified that the warning is outputted to stderr, not stdout (makes sure it doesn't break scripts that rely on outputs)