### PR TITLE
[v2.8] Update saml auth login endpoint to point toward dashboard endpoint

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -415,7 +415,7 @@ func samlAuth(input *LoginInput, tlsConfig *tls.Config) (managementClient.Token,
 
 	client := &http.Client{Transport: tr, Timeout: 300 * time.Second}
 
-	loginRequest := fmt.Sprintf("%s/login?requestId=%s&publicKey=%s&responseType=%s",
+	loginRequest := fmt.Sprintf("%s/dashboard/auth/login?requestId=%s&publicKey=%s&responseType=%s",
 		input.server, id, encodedKey, responseType)
 
 	customPrint(fmt.Sprintf("\nLogin to Rancher Server at %s \n", loginRequest))


### PR DESCRIPTION
Parent Issue: https://github.com/rancher/rancher/issues/41651
As per changes in https://github.com/rancher/dashboard/pull/9693 I have updated the SAML Auth login endpoint to use the new dashboard login path.