### PR TITLE
Fix panics in `rancher token` and `rancher server current` commands 

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -280,6 +280,9 @@ func cacheCredential(ctx *cli.Context, cred *config.ExecCredential, id string) e
 		return err
 	}
 
+	if sc.KubeCredentials[id] == nil {
+		sc.KubeCredentials = make(map[string]*config.ExecCredential)
+	}
 	sc.KubeCredentials[id] = cred
 	cf.Servers[server] = sc
 	return cf.Write()

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -71,8 +71,12 @@ func serverCurrent(ctx *cli.Context) error {
 	}
 
 	serverName := cf.CurrentServer
-	URL := cf.Servers[serverName].URL
-	fmt.Printf("Name: %s URL: %s\n", serverName, URL)
+	currentServer, found := cf.Servers[serverName]
+	if !found {
+		return errors.New("Current server not set")
+	}
+
+	fmt.Printf("Name: %s URL: %s\n", serverName, currentServer.URL)
 	return nil
 }
 


### PR DESCRIPTION
Fix https://github.com/rancher/rancher/issues/44332

As I've moved in this PR only the fix related to the panics. I'm going to then rebase the other PR.

# Bug Description

Some workflows will trigger panics due to assignment to nil maps, or a missing check:

```go
// sc.KubeCredentials is nil -> panics
sc.KubeCredentials[id] = cred
```

```go
serverName := cf.CurrentServer
// missing check for the existance of the value -> panics
URL := cf.Servers[serverName].URL
```

To reproduce just run a `rancher server current` without any configuration:

```
-> % rancher server current 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xa14869]

goroutine 1 [running]:
github.com/rancher/cli/cmd.serverCurrent(0xc000195b80?)
        /go/src/github.com/rancher/cli/cmd/server.go:74 +0xc9
github.com/urfave/cli.HandleAction({0xaa5b00?, 0xc28200?}, 0x7?)
...
```

or run a `rancher login` followed by a `rancher token`:

```
-> % rancher login https://myrancher.com --name https://myrancher.com --token MYTOKEN
INFO[0000] Saving config to /home/enrico/.rancher/cli2.json

###

-> % rancher token --server https://myrancher.com --user local
https://myrancher.com/v3-public/authProviders 
Enter credentials for localProvider 
 
Enter username: admin 
Enter password: 
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/rancher/cli/cmd.cacheCredential(0xc000274160, 0xc00032a2d0, {0xc0003326a0, 0x6})
        /go/src/github.com/rancher/cli/cmd/kubectl_token.go:283 +0x11a
github.com/rancher/cli/cmd.runCredential(0xc000274160)
        /go/src/github.com/rancher/cli/cmd/kubectl_token.go:165 +0x4a5
github.com/urfave/cli.HandleAction({0xaa5b00?, 0xc281f0?}, 0xc00011cfc0?)
        /go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:524 +0x50
github.com/urfave/cli.(*App).RunAsSubcommand(0xc00011cfc0, 0xc000274000)
        /go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:410 +0xabd
github.com/urfave/cli.Command.startApp({{0xbd2fb4, 0x5}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0xbf2956, 0x2e}, {0x0, ...}, ...}, ...)
        /go/pkg/mod/github.com/urfave/cli@v1.22.5/command.go:372 +0xb7f
github.com/urfave/cli.Command.Run({{0xbd2fb4, 0x5}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0xbf2956, 0x2e}, {0x0, ...}, ...}, ...)
        /go/pkg/mod/github.com/urfave/cli@v1.22.5/command.go:102 +0x845
github.com/urfave/cli.(*App).Run(0xc00011ce00, {0xc00004fd00, 0x6, 0x8})
        /go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:277 +0xb67
main.mainErr()
        /go/src/github.com/rancher/cli/main.go:136 +0x1f5d
main.main()
        /go/src/github.com/rancher/cli/main.go:57 +0x19
```