### PR TITLE
Cleanup of `rancher server` command

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	url2 "net/url"
@@ -24,7 +23,7 @@ import (
 	"github.com/rancher/norman/types/convert"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	"github.com/urfave/cli"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 const deleteExample = `
@@ -109,7 +108,7 @@ func CredentialCommand() cli.Command {
 			},
 		},
 		Subcommands: []cli.Command{
-			cli.Command{
+			{
 				Name:   "delete",
 				Usage:  deleteCommandUsage,
 				Action: deleteCachedCredential,
@@ -440,7 +439,7 @@ func samlAuth(input *LoginInput, tlsConfig *tls.Config) (managementClient.Token,
 			if err != nil {
 				return token, err
 			}
-			content, err := ioutil.ReadAll(res.Body)
+			content, err := io.ReadAll(res.Body)
 			if err != nil {
 				res.Body.Close()
 				return token, err
@@ -606,7 +605,7 @@ func request(method, url string, body io.Reader) ([]byte, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
-	response, err = ioutil.ReadAll(res.Body)
+	response, err = io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -619,7 +618,7 @@ func customPrompt(field string, show bool) (result string, err error) {
 		_, err = fmt.Fscan(os.Stdin, &result)
 	} else {
 		var data []byte
-		data, err = terminal.ReadPassword(int(os.Stdin.Fd()))
+		data, err = term.ReadPassword(int(os.Stdin.Fd()))
 		result = string(data)
 		fmt.Fprintf(os.Stderr, "\n")
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -30,12 +30,7 @@ func ServerCommand(cfg *config.Config) cli.Command {
 		Usage: "Operations for the server",
 		Description: `Switch or view the server currently in focus.
 `,
-		Before: func(ctx *cli.Context) error {
-			if len(cfg.Servers) == 0 {
-				return errors.New("no servers are currently configured")
-			}
-			return nil
-		},
+		Before: validateServersConfig(cfg),
 		Subcommands: []cli.Command{
 			{
 				Name:  "current",
@@ -239,4 +234,13 @@ func getServers(cfg *config.Config) []*serverData {
 	}
 
 	return servers
+}
+
+func validateServersConfig(cfg *config.Config) cli.BeforeFunc {
+	return func(ctx *cli.Context) error {
+		if len(cfg.Servers) == 0 {
+			return errors.New("no servers are currently configured")
+		}
+		return nil
+	}
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -105,6 +105,10 @@ func serverDelete(cfg *config.Config, serverName string) error {
 	}
 	delete(cfg.Servers, serverName)
 
+	if cfg.CurrentServer == serverName {
+		cfg.CurrentServer = ""
+	}
+
 	err := cfg.Write()
 	if err != nil {
 		return err

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -38,7 +38,7 @@ func ServerCommand() cli.Command {
 				Name:  "current",
 				Usage: "Display the current server",
 				Action: func(ctx *cli.Context) error {
-					return ServerCurrent(ctx.App.Writer, cfg)
+					return serverCurrent(ctx.App.Writer, cfg)
 				},
 			},
 			{
@@ -54,14 +54,14 @@ be displayed and one can be selected.
 					if err != nil {
 						return err
 					}
-					return ServerDelete(cfg, serverName)
+					return serverDelete(cfg, serverName)
 				},
 			},
 			{
 				Name:  "ls",
 				Usage: "List all servers",
 				Action: func(ctx *cli.Context) error {
-					return ServerLs(ctx, cfg)
+					return serverLs(ctx, cfg)
 				},
 			},
 			{
@@ -77,7 +77,7 @@ be displayed and one can be selected.
 					if err != nil {
 						return err
 					}
-					return ServerSwitch(cfg, serverName)
+					return serverSwitch(cfg, serverName)
 				},
 			},
 		},
@@ -85,7 +85,7 @@ be displayed and one can be selected.
 }
 
 // serverCurrent command to display the name of the current server in the local config
-func ServerCurrent(out io.Writer, cfg *config.Config) error {
+func serverCurrent(out io.Writer, cfg *config.Config) error {
 	serverName := cfg.CurrentServer
 
 	currentServer, found := cfg.Servers[serverName]
@@ -98,7 +98,7 @@ func ServerCurrent(out io.Writer, cfg *config.Config) error {
 }
 
 // serverDelete command to delete a server from the local config
-func ServerDelete(cfg *config.Config, serverName string) error {
+func serverDelete(cfg *config.Config, serverName string) error {
 	_, ok := cfg.Servers[serverName]
 	if !ok {
 		return errors.New("Server not found")
@@ -114,7 +114,7 @@ func ServerDelete(cfg *config.Config, serverName string) error {
 }
 
 // serverLs command to list rancher servers from the local config
-func ServerLs(ctx *cli.Context, cfg *config.Config) error {
+func serverLs(ctx *cli.Context, cfg *config.Config) error {
 	writer := NewTableWriter([][]string{
 		{"CURRENT", "Current"},
 		{"NAME", "Name"},
@@ -131,8 +131,8 @@ func ServerLs(ctx *cli.Context, cfg *config.Config) error {
 	return writer.Err()
 }
 
-// ServerSwitch will alter and write the config to switch rancher server.
-func ServerSwitch(cf *config.Config, serverName string) error {
+// serverSwitch will alter and write the config to switch rancher server.
+func serverSwitch(cf *config.Config, serverName string) error {
 	_, ok := cf.Servers[serverName]
 	if !ok {
 		return errors.New("Server not found")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"github.com/rancher/cli/config"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"golang.org/x/exp/maps"
 )
 
 type serverData struct {
@@ -22,17 +24,25 @@ type serverData struct {
 }
 
 // ServerCommand defines the 'rancher server' sub-commands
-func ServerCommand() cli.Command {
+func ServerCommand(cfg *config.Config) cli.Command {
 	return cli.Command{
 		Name:  "server",
 		Usage: "Operations for the server",
 		Description: `Switch or view the server currently in focus.
 `,
+		Before: func(ctx *cli.Context) error {
+			if len(cfg.Servers) == 0 {
+				return errors.New("no servers are currently configured")
+			}
+			return nil
+		},
 		Subcommands: []cli.Command{
 			{
-				Name:   "current",
-				Usage:  "Display the current server",
-				Action: serverCurrent,
+				Name:  "current",
+				Usage: "Display the current server",
+				Action: func(ctx *cli.Context) error {
+					return ServerCurrent(ctx.App.Writer, cfg)
+				},
 			},
 			{
 				Name:      "delete",
@@ -42,72 +52,63 @@ func ServerCommand() cli.Command {
 The server arg is optional, if not passed in a list of available servers will
 be displayed and one can be selected.
 `,
-				Action: serverDelete,
+				Action: func(ctx *cli.Context) error {
+					serverName, err := getSelectedServer(ctx, cfg)
+					if err != nil {
+						return err
+					}
+					return ServerDelete(cfg, serverName)
+				},
 			},
 			{
-				Name:   "ls",
-				Usage:  "List all servers",
-				Action: serverLs,
+				Name:  "ls",
+				Usage: "List all servers",
+				Action: func(ctx *cli.Context) error {
+					return ServerLs(ctx, cfg)
+				},
 			},
 			{
 				Name:      "switch",
 				Usage:     "Switch to a new server",
 				ArgsUsage: "[SERVER_NAME]",
 				Description: `
-The server arg is optional, if not passed in a list of available servers will
-be displayed and one can be selected.
-`,
-				Action: serverSwitch,
+		The server arg is optional, if not passed in a list of available servers will
+		be displayed and one can be selected.
+		`,
+				Action: func(ctx *cli.Context) error {
+					serverName, err := getSelectedServer(ctx, cfg)
+					if err != nil {
+						return err
+					}
+					return ServerSwitch(cfg, serverName)
+				},
 			},
 		},
 	}
 }
 
 // serverCurrent command to display the name of the current server in the local config
-func serverCurrent(ctx *cli.Context) error {
-	cf, err := loadConfig(ctx)
-	if err != nil {
-		return err
-	}
+func ServerCurrent(out io.Writer, cfg *config.Config) error {
+	serverName := cfg.CurrentServer
 
-	serverName := cf.CurrentServer
-	currentServer, found := cf.Servers[serverName]
+	currentServer, found := cfg.Servers[serverName]
 	if !found {
 		return errors.New("Current server not set")
 	}
 
-	fmt.Printf("Name: %s URL: %s\n", serverName, currentServer.URL)
+	fmt.Fprintf(out, "Name: %s URL: %s\n", serverName, currentServer.URL)
 	return nil
 }
 
 // serverDelete command to delete a server from the local config
-func serverDelete(ctx *cli.Context) error {
-	cf, err := loadConfig(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := validateServersConfig(cf); err != nil {
-		return err
-	}
-
-	var serverName string
-	if ctx.NArg() == 1 {
-		serverName = ctx.Args().First()
-	} else {
-		serverName, err = serverFromInput(ctx, cf)
-		if err != nil {
-			return err
-		}
-	}
-
-	_, ok := cf.Servers[serverName]
+func ServerDelete(cfg *config.Config, serverName string) error {
+	_, ok := cfg.Servers[serverName]
 	if !ok {
 		return errors.New("Server not found")
 	}
+	delete(cfg.Servers, serverName)
 
-	delete(cf.Servers, serverName)
-	err = cf.Write()
+	err := cfg.Write()
 	if err != nil {
 		return err
 	}
@@ -116,16 +117,7 @@ func serverDelete(ctx *cli.Context) error {
 }
 
 // serverLs command to list rancher servers from the local config
-func serverLs(ctx *cli.Context) error {
-	cf, err := loadConfig(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := validateServersConfig(cf); err != nil {
-		return err
-	}
-
+func ServerLs(ctx *cli.Context, cfg *config.Config) error {
 	writer := NewTableWriter([][]string{
 		{"CURRENT", "Current"},
 		{"NAME", "Name"},
@@ -134,41 +126,16 @@ func serverLs(ctx *cli.Context) error {
 
 	defer writer.Close()
 
-	for name, server := range cf.Servers {
-		var current string
-		if name == cf.CurrentServer {
-			current = "*"
-		}
-		writer.Write(&serverData{
-			Current: current,
-			Name:    name,
-			URL:     server.URL,
-		})
+	servers := getServers(cfg)
+	for _, server := range servers {
+		writer.Write(server)
 	}
 
 	return writer.Err()
 }
 
-// serverSwitch command to switch rancher server.
-func serverSwitch(ctx *cli.Context) error {
-	cf, err := loadConfig(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := validateServersConfig(cf); err != nil {
-		return err
-	}
-
-	var serverName string
-	if ctx.NArg() == 1 {
-		serverName = ctx.Args().First()
-	} else {
-		serverName, err = serverFromInput(ctx, cf)
-		if err != nil {
-			return err
-		}
-	}
+// ServerSwitch will alter and write the config to switch rancher server.
+func ServerSwitch(cf *config.Config, serverName string) error {
 	_, ok := cf.Servers[serverName]
 	if !ok {
 		return errors.New("Server not found")
@@ -179,25 +146,34 @@ func serverSwitch(ctx *cli.Context) error {
 	}
 
 	cf.CurrentServer = serverName
-	err = cf.Write()
+
+	err := cf.Write()
 	if err != nil {
 		return err
 	}
-
 	return nil
+}
+
+// getSelectedServer will get the selected server if provided as argument,
+// or it will prompt the user to select one.
+func getSelectedServer(ctx *cli.Context, cfg *config.Config) (string, error) {
+	serverName := ctx.Args().First()
+	if serverName != "" {
+		return serverName, nil
+	}
+	return serverFromInput(ctx, cfg)
 }
 
 // serverFromInput displays the list of servers from the local config and
 // prompt the user to select one.
-func serverFromInput(ctx *cli.Context, cf config.Config) (string, error) {
-	serverNames := getServerNames(cf)
-
-	displayListServers(ctx, cf)
+func serverFromInput(ctx *cli.Context, cf *config.Config) (string, error) {
+	servers := getServers(cf)
+	displayListServers(ctx, servers)
 
 	fmt.Print("Select a Server:")
 	reader := bufio.NewReader(os.Stdin)
 
-	errMessage := fmt.Sprintf("Invalid input, enter a number between 1 and %v: ", len(serverNames))
+	errMessage := fmt.Sprintf("Invalid input, enter a number between 1 and %v: ", len(servers))
 	var selection int
 
 	for {
@@ -213,7 +189,7 @@ func serverFromInput(ctx *cli.Context, cf config.Config) (string, error) {
 				fmt.Print(errMessage)
 				continue
 			}
-			if i <= len(serverNames) && i != 0 {
+			if i <= len(servers) && i != 0 {
 				selection = i - 1
 				break
 			}
@@ -222,11 +198,11 @@ func serverFromInput(ctx *cli.Context, cf config.Config) (string, error) {
 		}
 	}
 
-	return serverNames[selection], nil
+	return servers[selection].Name, nil
 }
 
 // displayListServers displays the list of rancher servers
-func displayListServers(ctx *cli.Context, cf config.Config) error {
+func displayListServers(ctx *cli.Context, servers []*serverData) error {
 	writer := NewTableWriter([][]string{
 		{"INDEX", "Index"},
 		{"NAME", "Name"},
@@ -235,29 +211,32 @@ func displayListServers(ctx *cli.Context, cf config.Config) error {
 
 	defer writer.Close()
 
-	for idx, server := range getServerNames(cf) {
-		writer.Write(&serverData{
-			Index: idx + 1,
-			Name:  server,
-			URL:   cf.Servers[server].URL,
-		})
+	for _, server := range servers {
+		writer.Write(server)
 	}
 	return writer.Err()
 }
 
-// getServerNames returns an order slice of existing server names
-func getServerNames(cf config.Config) []string {
-	var serverNames []string
-	for server := range cf.Servers {
-		serverNames = append(serverNames, server)
-	}
+// getServers returns an ordered slice (by name) of serverData
+func getServers(cfg *config.Config) []*serverData {
+	serverNames := maps.Keys(cfg.Servers)
 	sort.Strings(serverNames)
-	return serverNames
-}
 
-func validateServersConfig(cnf config.Config) error {
-	if len(cnf.Servers) == 0 {
-		return errors.New("no servers are currently configured")
+	servers := []*serverData{}
+
+	for i, server := range serverNames {
+		var current string
+		if server == cfg.CurrentServer {
+			current = "*"
+		}
+
+		servers = append(servers, &serverData{
+			Index:   i + 1,
+			Name:    server,
+			Current: current,
+			URL:     cfg.Servers[server].URL,
+		})
 	}
-	return nil
+
+	return servers
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -61,7 +61,8 @@ be displayed and one can be selected.
 				Name:  "ls",
 				Usage: "List all servers",
 				Action: func(ctx *cli.Context) error {
-					return serverLs(ctx, cfg)
+					format := ctx.String("format")
+					return serverLs(ctx.App.Writer, cfg, format)
 				},
 			},
 			{
@@ -118,12 +119,17 @@ func serverDelete(cfg *config.Config, serverName string) error {
 }
 
 // serverLs command to list rancher servers from the local config
-func serverLs(ctx *cli.Context, cfg *config.Config) error {
-	writer := NewTableWriter([][]string{
+func serverLs(out io.Writer, cfg *config.Config, format string) error {
+	writerConfig := &TableWriterConfig{
+		Writer: out,
+		Format: format,
+	}
+
+	writer := NewTableWriterWithConfig([][]string{
 		{"CURRENT", "Current"},
 		{"NAME", "Name"},
 		{"URL", "URL"},
-	}, ctx)
+	}, writerConfig)
 
 	defer writer.Close()
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -24,13 +24,15 @@ type serverData struct {
 }
 
 // ServerCommand defines the 'rancher server' sub-commands
-func ServerCommand(cfg *config.Config) cli.Command {
+func ServerCommand() cli.Command {
+	cfg := &config.Config{}
+
 	return cli.Command{
 		Name:  "server",
 		Usage: "Operations for the server",
 		Description: `Switch or view the server currently in focus.
 `,
-		Before: validateServersConfig(cfg),
+		Before: loadAndValidateConfig(cfg),
 		Subcommands: []cli.Command{
 			{
 				Name:  "current",
@@ -236,8 +238,14 @@ func getServers(cfg *config.Config) []*serverData {
 	return servers
 }
 
-func validateServersConfig(cfg *config.Config) cli.BeforeFunc {
+func loadAndValidateConfig(cfg *config.Config) cli.BeforeFunc {
 	return func(ctx *cli.Context) error {
+		conf, err := loadConfig(ctx)
+		if err != nil {
+			return err
+		}
+		*cfg = conf
+
 		if len(cfg.Servers) == 0 {
 			return errors.New("no servers are currently configured")
 		}

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1,11 +1,10 @@
-package cmd_test
+package cmd
 
 import (
 	"bytes"
 	"os"
 	"testing"
 
-	"github.com/rancher/cli/cmd"
 	"github.com/rancher/cli/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -48,7 +47,7 @@ func TestServerCurrentCommand(t *testing.T) {
 			t.Parallel()
 			out := &bytes.Buffer{}
 
-			err := cmd.ServerCurrent(out, tc.config)
+			err := serverCurrent(out, tc.config)
 			if tc.expectedErr != "" {
 				assert.EqualError(t, err, tc.expectedErr)
 			} else {
@@ -110,7 +109,7 @@ func TestServerSwitch(t *testing.T) {
 			cfg.CurrentServer = tc.actualCurrentServer
 
 			// do test and check resulting config
-			err = cmd.ServerSwitch(cfg, tc.serverName)
+			err = serverSwitch(cfg, tc.serverName)
 			if err != nil {
 				assert.EqualError(t, err, tc.expectedErr)
 			} else {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1,0 +1,126 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/rancher/cli/cmd"
+	"github.com/rancher/cli/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerCurrentCommand(t *testing.T) {
+	tt := []struct {
+		name           string
+		config         *config.Config
+		expectedOutput string
+	}{
+		{
+			name:           "existing current server set",
+			config:         newTestConfig(),
+			expectedOutput: "Name: server1 URL: https://myserver-1.com\n",
+		},
+		{
+			name: "empty current server",
+			config: func() *config.Config {
+				cfg := newTestConfig()
+				cfg.CurrentServer = ""
+				return cfg
+			}(),
+			expectedOutput: "Current server not set\n",
+		},
+		{
+			name: "non existing current server set",
+			config: &config.Config{
+				CurrentServer: "notfound-server",
+				Servers: map[string]*config.ServerConfig{
+					"my-server": {URL: "https://myserver.com"},
+				},
+			},
+			expectedOutput: "Current server not set\n",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+
+			out := &bytes.Buffer{}
+			err := cmd.ServerCurrent(out, tc.config)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedOutput, out.String())
+		})
+	}
+}
+
+func TestServerSwitch(t *testing.T) {
+	tt := []struct {
+		name                  string
+		actualCurrentServer   string
+		serverName            string
+		expectedCurrentServer string
+		expectedErr           string
+	}{
+		{
+			name:                  "switch to different server updates the current server",
+			actualCurrentServer:   "server1",
+			serverName:            "server3",
+			expectedCurrentServer: "server3",
+		},
+		{
+			name:                  "switch to same server is no-op",
+			actualCurrentServer:   "server1",
+			serverName:            "server1",
+			expectedCurrentServer: "server1",
+		},
+		{
+			name:                  "switch to non existing server",
+			actualCurrentServer:   "server1",
+			serverName:            "server-nope",
+			expectedCurrentServer: "server1",
+			expectedErr:           "Server not found",
+		},
+		{
+			name:                  "switch to empty server fails",
+			actualCurrentServer:   "server1",
+			serverName:            "",
+			expectedCurrentServer: "server1",
+			expectedErr:           "Server not found",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+
+			tmpConfig, err := os.CreateTemp("", "*-rancher-config.json")
+			assert.NoError(t, err)
+			defer os.Remove(tmpConfig.Name())
+
+			// setup test config
+			cfg := newTestConfig()
+			cfg.Path = tmpConfig.Name()
+			cfg.CurrentServer = tc.actualCurrentServer
+
+			// do test and check resulting config
+			err = cmd.ServerSwitch(cfg, tc.serverName)
+			if err != nil {
+				assert.EqualError(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedCurrentServer, cfg.CurrentServer)
+		})
+	}
+}
+
+func newTestConfig() *config.Config {
+	return &config.Config{
+		CurrentServer: "server1",
+		Servers: map[string]*config.ServerConfig{
+			"server1": {URL: "https://myserver-1.com"},
+			"server2": {URL: "https://myserver-2.com"},
+			"server3": {URL: "https://myserver-3.com"},
+		},
+	}
+}

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -15,6 +15,7 @@ func TestServerCurrentCommand(t *testing.T) {
 		name           string
 		config         *config.Config
 		expectedOutput string
+		expectedErr    string
 	}{
 		{
 			name:           "existing current server set",
@@ -28,7 +29,7 @@ func TestServerCurrentCommand(t *testing.T) {
 				cfg.CurrentServer = ""
 				return cfg
 			}(),
-			expectedOutput: "Current server not set\n",
+			expectedErr: "Current server not set",
 		},
 		{
 			name: "non existing current server set",
@@ -38,16 +39,21 @@ func TestServerCurrentCommand(t *testing.T) {
 					"my-server": {URL: "https://myserver.com"},
 				},
 			},
-			expectedOutput: "Current server not set\n",
+			expectedErr: "Current server not set",
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
-
 			out := &bytes.Buffer{}
+
 			err := cmd.ServerCurrent(out, tc.config)
-			assert.NoError(t, err)
+			if tc.expectedErr != "" {
+				assert.EqualError(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
 			assert.Equal(t, tc.expectedOutput, out.String())
 		})
 	}

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -43,8 +43,9 @@ func TestServerCurrentCommand(t *testing.T) {
 		},
 	}
 	for _, tc := range tt {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
+			t.Parallel()
 			out := &bytes.Buffer{}
 
 			err := cmd.ServerCurrent(out, tc.config)
@@ -95,8 +96,9 @@ func TestServerSwitch(t *testing.T) {
 		},
 	}
 	for _, tc := range tt {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
+			t.Parallel()
 
 			tmpConfig, err := os.CreateTemp("", "*-rancher-config.json")
 			assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,9 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.5
-	golang.org/x/crypto v0.11.0
+	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/term v0.10.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/client-go v12.0.0+incompatible
@@ -31,7 +32,7 @@ require (
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
@@ -49,10 +50,10 @@ require (
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.10.0 // indirect
-	golang.org/x/term v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	google.golang.org/appengine v1.6.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -519,6 +520,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 h1:/RIbNt/Zr7rVhIkQhooTxCxFcdWLGIKnZA4IXNFSrvo=
+golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -701,7 +704,6 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=

--- a/main.go
+++ b/main.go
@@ -60,6 +60,8 @@ func main() {
 }
 
 func mainErr() error {
+	cfg := &config.Config{}
+
 	cli.AppHelpTemplate = AppHelpTemplate
 	cli.CommandHelpTemplate = CommandHelpTemplate
 	cli.SubcommandHelpTemplate = SubcommandHelpTemplate
@@ -81,6 +83,12 @@ func mainErr() error {
 		for _, warning := range warnings {
 			logrus.Warning(warning)
 		}
+
+		conf, err := config.LoadFromPath(path)
+		if err != nil {
+			return err
+		}
+		*cfg = conf
 
 		return nil
 	}
@@ -114,7 +122,7 @@ func mainErr() error {
 		cmd.NodeCommand(),
 		cmd.ProjectCommand(),
 		cmd.PsCommand(),
-		cmd.ServerCommand(),
+		cmd.ServerCommand(cfg),
 		cmd.SettingsCommand(),
 		cmd.SSHCommand(),
 		cmd.UpCommand(),

--- a/main.go
+++ b/main.go
@@ -60,8 +60,6 @@ func main() {
 }
 
 func mainErr() error {
-	cfg := &config.Config{}
-
 	cli.AppHelpTemplate = AppHelpTemplate
 	cli.CommandHelpTemplate = CommandHelpTemplate
 	cli.SubcommandHelpTemplate = SubcommandHelpTemplate
@@ -83,12 +81,6 @@ func mainErr() error {
 		for _, warning := range warnings {
 			logrus.Warning(warning)
 		}
-
-		conf, err := config.LoadFromPath(path)
-		if err != nil {
-			return err
-		}
-		*cfg = conf
 
 		return nil
 	}
@@ -122,7 +114,7 @@ func mainErr() error {
 		cmd.NodeCommand(),
 		cmd.ProjectCommand(),
 		cmd.PsCommand(),
-		cmd.ServerCommand(cfg),
+		cmd.ServerCommand(),
 		cmd.SettingsCommand(),
 		cmd.SSHCommand(),
 		cmd.UpCommand(),


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/44374

This PR contains the refactor of the https://github.com/rancher/cli/pull/347.
The panics fix where added with https://github.com/rancher/cli/pull/348

# Description

Fixing the panics I took the opportunity to cleanup a bit the code (only the `server` command, to avoid a huge and "critical" refactor). The server command is pretty safe to play with.

Also some deprecated deps were updated (`terminal` and `ioutil`).

### 1) Common validation

The server commands are expecting a valid server configuration:

```go
func validateServersConfig(cnf config.Config) error {
	// do validation validate
}
```

This common validation was changed to a `cli.BeforeFunc` and added in the `Before` of the `server` commands.

### 2) Testing

To make test possible I moved the business logic to their dedicated func, dropping (when possible) the dependency from the `cli.Context`.

I.e.: the `ServerCurrent` now accept an `io.Writer` and a `*config.Config`. Or the `ServerSwitch` now needs only the `*config.Config` and the `serverName`. This made test possible (and tests were added).

### 3) Centralized Config

The `*config.Config` is needed by every commands, and loaded every time in the same (?) way. This can be done only once at the very start of the root command, in the BeforeFunc. Then the Config can be just passed as a dependency to the commands.

Be aware that to make this work a pointer has to be passed downward, and update the underlying struct in the Before. This is because in Go arguments are passe by value, and the Commands are built before the actual Run (obviously). So the pointer will be always the same, but it will point to the just loaded conf.

```go
conf, err := config.LoadFromPath(path)
if err != nil {
	return err
}
*cfg = conf
```

With this approach we can drop all the `loadConfig` in every command:

```go
// not needed anymore
cf, err := loadConfig(ctx)
if err != nil {
	return err
}
```

### 4) Simplifications

Some minor cleanup, like the `getServers(cfg *config.Config) []*serverData` func.
Instead of getting the ordered keys, and then loop through them we can simply use the already existing `serverData` struct.

This will return an ordered slice of `serverData` that will be used by the server prompt selection, and also by the `ServerLs`, that was using an unordered set of servers (now it's consistent).