### PR TITLE
add username flag for token command

### DIFF
--- a/cmd/kubectl_token.go
+++ b/cmd/kubectl_token.go
@@ -42,6 +42,7 @@ Example:
 type LoginInput struct {
 	server       string
 	userID       string
+	username     string
 	clusterID    string
 	authProvider string
 	caCerts      string
@@ -96,6 +97,10 @@ func CredentialCommand() cli.Command {
 			cli.StringFlag{
 				Name:  "user",
 				Usage: "user-id",
+			},
+			cli.StringFlag{
+				Name:  "username",
+				Usage: "Username for basic auth",
 			},
 			cli.StringFlag{
 				Name:  "cluster",
@@ -161,6 +166,7 @@ func runCredential(ctx *cli.Context) error {
 		authProvider: ctx.String("auth-provider"),
 		caCerts:      ctx.String("cacerts"),
 		skipVerify:   ctx.Bool("skip-verify"),
+		username:     ctx.String("username"),
 	}
 
 	newCred, err := loginAndGenerateCred(input)
@@ -342,9 +348,14 @@ func loginAndGenerateCred(input *LoginInput) (*config.ExecCredential, error) {
 
 func basicAuth(input *LoginInput, tlsConfig *tls.Config) (managementClient.Token, error) {
 	token := managementClient.Token{}
-	username, err := customPrompt("username", true)
-	if err != nil {
-		return token, err
+
+	username := input.username
+	if username == "" {
+		var err error
+		username, err = customPrompt("username", true)
+		if err != nil {
+			return token, err
+		}
 	}
 
 	password, err := customPrompt("password", false)


### PR DESCRIPTION
This PR allows us to pass the username as a flag to the `rancher token` command so it does not need to be input each time. This is helpful in Kubernetes configs when defining the login command for a given cluster.

Example
```sh
$ ranch token --server=my-server --user=my-user --cluster=my-cluster --auth-provider=activeDirectoryProvider --username my-username
Enter credentials for activeDirectoryProvider

Enter password:
```
As we can see it no longer asks for a username if one is passed in.