### PR TITLE
[v2.9] Bump to Go 1.22

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,8 +1,8 @@
-FROM registry.suse.com/bci/golang:1.20
+FROM registry.suse.com/bci/golang:1.22
 
 RUN zypper -n install docker rsync xz zip
 
-ENV GOLANGCI_LINT v1.53.3
+ENV GOLANGCI_LINT v1.57.1
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "$GOLANGCI_LINT"
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/cli

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cli
 
-go 1.20
+go 1.22
 
 replace k8s.io/client-go => k8s.io/client-go v0.20.1
 


### PR DESCRIPTION
Because of the bump of Rancher to Go 1.22 ([here](https://github.com/rancher/rancher/pull/44684)) we need to bump the CLI as well.

We probably needed this anyway.

Needed because of this other PR: https://github.com/rancher/cli/pull/346
Original issue: https://github.com/rancher/rancher/issues/42939