### PR TITLE
[v2.8] Go1.21 update

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,8 +1,8 @@
-FROM registry.suse.com/bci/golang:1.20
+FROM registry.suse.com/bci/golang:1.21
 
 RUN zypper -n install docker rsync xz zip
 
-ENV GOLANGCI_LINT v1.53.3
+ENV GOLANGCI_LINT v1.57.1
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "$GOLANGCI_LINT"
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/cli

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/cli
 
-go 1.20
+go 1.21
 
 replace k8s.io/client-go => k8s.io/client-go v0.20.1
 


### PR DESCRIPTION
Bump of Go to 1.21 to get the latest security fixes, and fix the issue with https://github.com/rancher/cli/pull/359