### PR TITLE
Fix GitHub Action permission to publish assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
+      contents: write # needed to create/update the release with the assets
       id-token: write # needed for the Vault authentication
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     permissions:
-      contents: read
+      contents: write
       id-token: write # needed for the Vault authentication
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The testing release `v2.9.0-rc2` failed: https://github.com/rancher/cli/actions/runs/8999212629/job/24720925994

Error was `HTTP 403: Resource not accessible by integration` because the `contents` permission was set to `read`, while the needed permission to update a release should be `write`.

Added `contents: write` permission in release workflow.