### PR TITLE
[v2.9] Use Rancher org FOSSA secret

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -24,7 +24,7 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/fossa/credentials token | FOSSA
+            secret/data/github/org/rancher/fossa/push token | FOSSA
 
       - name: Check FOSSA compliance
         uses: fossas/fossa-action@main


### PR DESCRIPTION
This PR updates the action to use the Rancher org FOSSA secret instead of the repo one.