### PR TITLE
[v2.9] Upload CLI assets to GCS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,18 @@ jobs:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/google-auth/rancher/credentials token  | GOOGLE_AUTH ;
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USERNAME }}
         password: ${{ env.DOCKER_PASSWORD }}
+
+    - name: Authenticate to Google Cloud 
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: "${{ env.GOOGLE_AUTH }}"
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -74,6 +80,14 @@ jobs:
         # generate sha256sum file
         find . -maxdepth 1 -type f ! -name sha256sum.txt -printf '%P\0' | xargs -0 sha256sum > sha256sum.txt
         gh release upload $VERSION *.txt *.xz *.gz *.zip
+
+    - name: Upload Release assets to Google Cloud
+      uses: google-github-actions/upload-cloud-storage@v2
+      with:
+        path: dist/artifacts/$VERSION
+        destination: releases.rancher.com/cli2/$VERSION
+        headers: |-
+          cache-control: public,max-age=3600
 
     - name: Docker Build
       uses: docker/build-push-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,11 @@ jobs:
     - name: Upload Release assets to Google Cloud
       uses: google-github-actions/upload-cloud-storage@v2
       with:
-        path: dist/artifacts/$VERSION
-        destination: releases.rancher.com/cli2/$VERSION
+        path: dist/artifacts/${{ env.VERSION }}
+        destination: releases.rancher.com/cli2/${{ env.VERSION }}
+        glob: '*.*' # copy only the files in the path folder
+        parent: false
+        process_gcloudignore: false
         headers: |-
           cache-control: public,max-age=3600
 


### PR DESCRIPTION
This PR uploads the release assets to Google Cloud Storage.

FIx: https://github.com/rancher/rancher/issues/46068

Ref: https://github.com/rancher/dashboard/blob/master/.github/workflows/build-and-upload.yaml#L89-L110