### PR TITLE
[v2.8] Upload CLI assets to GCS - fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,8 @@ jobs:
     - name: Upload Release assets to Google Cloud
       uses: google-github-actions/upload-cloud-storage@v2
       with:
-        path: dist/artifacts/$VERSION
-        destination: releases.rancher.com/cli2/$VERSION
+        path: dist/artifacts/${{ env.VERSION }}
+        destination: releases.rancher.com/cli2/${{ env.VERSION }}
         headers: |-
           cache-control: public,max-age=3600
 


### PR DESCRIPTION
Ref: https://github.com/rancher/cli/pull/378

Fix for env var: https://github.com/rancher/cli/actions/runs/9892030076/job/27323739480

```
Error: google-github-actions/upload-cloud-storage failed with: ENOENT: no such file or directory, lstat '/home/runner/work/cli/cli/dist/artifacts/$VERSION'
```