### PR TITLE
[v2.8] Upload CLI assets to GCS - fix2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
       with:
         path: dist/artifacts/${{ env.VERSION }}
         destination: releases.rancher.com/cli2/${{ env.VERSION }}
+        glob: '*.*' # copy only the files in the path folder
+        parent: false
+        process_gcloudignore: false
         headers: |-
           cache-control: public,max-age=3600
 


### PR DESCRIPTION
This PR will fix the previous download attempts with the right path.

To validate this I create a workflow trying to upload the assets to a custom bucket: https://github.com/enrichman/cli/actions/runs/9904028207/job/27360623783

```
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-darwin-amd64-v2.8.6-rc7.tar.gz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-darwin-amd64-v2.8.6-rc7.tar.gz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-darwin-amd64-v2.8.6-rc7.tar.xz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-darwin-amd64-v2.8.6-rc7.tar.xz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-darwin-arm64-v2.8.6-rc7.tar.gz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-darwin-arm64-v2.8.6-rc7.tar.gz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-darwin-arm64-v2.8.6-rc7.tar.xz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-darwin-arm64-v2.8.6-rc7.tar.xz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-linux-amd64-v2.8.6-rc7.tar.gz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-linux-amd64-v2.8.6-rc7.tar.gz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-linux-amd64-v2.8.6-rc7.tar.xz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-linux-amd64-v2.8.6-rc7.tar.xz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-linux-arm-v2.8.6-rc7.tar.gz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-linux-arm-v2.8.6-rc7.tar.gz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-linux-arm-v2.8.6-rc7.tar.xz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-linux-arm-v2.8.6-rc7.tar.xz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-linux-s390x-v2.8.6-rc7.tar.gz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-linux-s390x-v2.8.6-rc7.tar.gz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-linux-s390x-v2.8.6-rc7.tar.xz to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-linux-s390x-v2.8.6-rc7.tar.xz
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-windows-386-v2.8.6-rc7.zip to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-windows-386-v2.8.6-rc7.zip
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/rancher-windows-amd64-v2.8.6-rc7.zip to gs://ecandino-bucket/cli2/v2.8.6-rc7/rancher-windows-amd64-v2.8.6-rc7.zip
Uploading /home/runner/work/cli/cli/dist/artifacts/v2.8.6-rc7/sha256sum.txt to gs://ecandino-bucket/cli2/v2.8.6-rc7/sha256sum.txt
```

Ref:

- https://github.com/rancher/cli/pull/378
- https://github.com/rancher/cli/pull/380