### PR TITLE
rancher cli - readable-world and readable-user warnings have no meaning on windows client

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -74,11 +75,13 @@ func GetFilePermissionWarnings(path string) ([]string, error) {
 	}
 
 	var warnings []string
-	if info.Mode()&0040 > 0 {
-		warnings = append(warnings, fmt.Sprintf("Rancher configuration file %s is group-readable. This is insecure.", path))
-	}
-	if info.Mode()&0004 > 0 {
-		warnings = append(warnings, fmt.Sprintf("Rancher configuration file %s is world-readable. This is insecure.", path))
+	if runtime.GOOS != "windows" {
+		if info.Mode()&0040 > 0 {
+			warnings = append(warnings, fmt.Sprintf("Rancher configuration file %s is group-readable. This is insecure.", path))
+		}
+		if info.Mode()&0004 > 0 {
+			warnings = append(warnings, fmt.Sprintf("Rancher configuration file %s is world-readable. This is insecure.", path))
+		}
 	}
 	return warnings, nil
 }


### PR DESCRIPTION
This warning have no meaning on windows:

```
PS C:\dist\dev\cli> rancher.exe context current
time="2024-08-21T15:08:25+02:00" level=warning msg="Rancher configuration file C:\\Users\\mobj\\.rancher\\cli2.json is group-readable. This is insecure."
time="2024-08-21T15:08:25+02:00" level=warning msg="Rancher configuration file C:\\Users\\mobj\\.rancher\\cli2.json is world-readable. This is insecure."
PS C:\dist\dev\cli> go build
Cluster:backend-test-osl Project:TSP
PS C:\dist\dev\cli> .\cli.exe context current
Cluster:backend-test-osl Project:TSP
```