### PR TITLE
[v2.8] Fix panic on context switch

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -7,6 +7,7 @@ on:
       - v*
     branches:
       - v*
+      - main
 
 jobs:
   fossa:

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -148,7 +148,11 @@ func getKubeConfigForUser(ctx *cli.Context, user string) (*api.Config, error) {
 		return nil, err
 	}
 
-	focusedServer := cf.FocusedServer()
+	focusedServer, err := cf.FocusedServer()
+	if err != nil {
+		return nil, err
+	}
+
 	kubeConfig := focusedServer.KubeConfigs[fmt.Sprintf(kubeConfigKeyFormat, user, focusedServer.FocusedCluster())]
 	return kubeConfig, nil
 }
@@ -159,10 +163,15 @@ func setKubeConfigForUser(ctx *cli.Context, user string, kubeConfig *api.Config)
 		return err
 	}
 
-	if cf.FocusedServer().KubeConfigs == nil {
-		cf.FocusedServer().KubeConfigs = make(map[string]*api.Config)
+	focusedServer, err := cf.FocusedServer()
+	if err != nil {
+		return err
 	}
-	focusedServer := cf.FocusedServer()
+
+	if focusedServer.KubeConfigs == nil {
+		focusedServer.KubeConfigs = make(map[string]*api.Config)
+	}
+
 	focusedServer.KubeConfigs[fmt.Sprintf(kubeConfigKeyFormat, user, focusedServer.FocusedCluster())] = kubeConfig
 	return cf.Write()
 }
@@ -273,9 +282,9 @@ func lookupConfig(ctx *cli.Context) (*config.ServerConfig, error) {
 		return nil, err
 	}
 
-	cs := cf.FocusedServer()
-	if cs == nil {
-		return nil, errors.New("no configuration found, run `login`")
+	cs, err := cf.FocusedServer()
+	if err != nil {
+		return nil, err
 	}
 
 	return cs, nil

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -39,7 +39,11 @@ func contextSwitch(ctx *cli.Context) error {
 		return err
 	}
 
-	server := cf.FocusedServer()
+	server, err := cf.FocusedServer()
+	if err != nil {
+		return err
+	}
+
 	c, err := cliclient.NewManagementClient(server)
 	if err != nil {
 		return err

--- a/cmd/kubectl.go
+++ b/cmd/kubectl.go
@@ -46,9 +46,9 @@ func runKubectl(ctx *cli.Context) error {
 		return err
 	}
 
-	currentRancherServer := config.FocusedServer()
-	if currentRancherServer == nil {
-		return fmt.Errorf("no focused server")
+	currentRancherServer, err := config.FocusedServer()
+	if err != nil {
+		return err
 	}
 
 	currentToken := currentRancherServer.AccessKey

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -11,6 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
+
+var ErrNoServerSelected = errors.New("no server selected")
 
 // Config holds the main config for the user
 type Config struct {
@@ -100,8 +103,12 @@ func (c Config) Write() error {
 	return json.NewEncoder(output).Encode(c)
 }
 
-func (c Config) FocusedServer() *ServerConfig {
-	return c.Servers[c.CurrentServer]
+func (c Config) FocusedServer() (*ServerConfig, error) {
+	currentServer, found := c.Servers[c.CurrentServer]
+	if !found || currentServer == nil {
+		return nil, ErrNoServerSelected
+	}
+	return currentServer, nil
 }
 
 func (c ServerConfig) FocusedCluster() string {


### PR DESCRIPTION
Ref: https://github.com/rancher/rancher/issues/46933

- backport: https://github.com/rancher/rancher/issues/45340
- `main` PR: https://github.com/rancher/cli/pull/386

---

Switching an empty context will cause a panic.

Added an `ErrNoServerSelected` error on the `FocusedServer()` func to force the check of a valid focused server.