### PR TITLE
[2.11] Avoid permissions errors on Windows

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -65,6 +66,13 @@ func LoadFromPath(path string) (Config, error) {
 // We want this because configuration may have sensitive information (eg: creds).
 // A nil error is returned if the file doesn't exist.
 func GetFilePermissionWarnings(path string) ([]string, error) {
+	// Permission bits on Windows are not representative
+	// of the actual ACLs set for a given file. As the owner
+	// bit is always used for all three bits on Windows, this check
+	// will always fail, even if the file has restricted access to admins only.
+	if runtime.GOOS == "windows" {
+		return nil, nil
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
### Issue: https://github.com/rancher/rancher/issues/46769

This PR updates `GetFilePermissionWarnings` to ignore Windows platforms. The current file permission checks are not appropriate for Windows as Go does not handle permission bits in the same way as it does on Linux. For Windows, Go will only use the owner bit, effectively turning `600` into `666`. Access Control Lists are the intended means of securing files, and the cli currently sets the ACLs properly, only allowing access to the local system and administrators.  