### PR TITLE
Respect proxy settings and set http timeout in login and ssh commands

### DIFF
--- a/cliclient/cliclient.go
+++ b/cliclient/cliclient.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	errorsPkg "github.com/pkg/errors"
 	"github.com/rancher/cli/config"
@@ -185,7 +186,13 @@ func createClientOpts(config *config.ServerConfig) *clientbase.ClientOpts {
 		AccessKey: config.AccessKey,
 		SecretKey: config.SecretKey,
 		CACerts:   config.CACerts,
+		ProxyURL:  config.ProxyURL,
 	}
+
+	if config.HTTPTimeoutSeconds > 0 {
+		options.Timeout = time.Duration(config.HTTPTimeoutSeconds) * time.Second
+	}
+
 	return options
 }
 

--- a/cliclient/cliclient.go
+++ b/cliclient/cliclient.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	errorsPkg "github.com/pkg/errors"
 	"github.com/rancher/cli/config"
@@ -181,19 +180,14 @@ func createClientOpts(config *config.ServerConfig) *clientbase.ClientOpts {
 		serverURL = config.URL + "/v3"
 	}
 
-	options := &clientbase.ClientOpts{
+	return &clientbase.ClientOpts{
 		URL:       serverURL,
 		AccessKey: config.AccessKey,
 		SecretKey: config.SecretKey,
 		CACerts:   config.CACerts,
 		ProxyURL:  config.ProxyURL,
+		Timeout:   config.GetHTTPTimeout(),
 	}
-
-	if config.HTTPTimeoutSeconds > 0 {
-		options.Timeout = time.Duration(config.HTTPTimeoutSeconds) * time.Second
-	}
-
-	return options
 }
 
 func SplitOnColon(s string) []string {

--- a/config/config.go
+++ b/config/config.go
@@ -26,14 +26,16 @@ type Config struct {
 
 // ServerConfig holds the config for each server the user has setup
 type ServerConfig struct {
-	AccessKey       string                     `json:"accessKey"`
-	SecretKey       string                     `json:"secretKey"`
-	TokenKey        string                     `json:"tokenKey"`
-	URL             string                     `json:"url"`
-	Project         string                     `json:"project"`
-	CACerts         string                     `json:"cacert"`
-	KubeCredentials map[string]*ExecCredential `json:"kubeCredentials"`
-	KubeConfigs     map[string]*api.Config     `json:"kubeConfigs"`
+	AccessKey          string                     `json:"accessKey"`
+	SecretKey          string                     `json:"secretKey"`
+	TokenKey           string                     `json:"tokenKey"`
+	URL                string                     `json:"url"`
+	Project            string                     `json:"project"`
+	CACerts            string                     `json:"cacert"`
+	KubeCredentials    map[string]*ExecCredential `json:"kubeCredentials"`
+	KubeConfigs        map[string]*api.Config     `json:"kubeConfigs"`
+	ProxyURL           string                     `json:"proxyUrl"`
+	HTTPTimeoutSeconds int                        `json:"httpTimeoutSeconds"`
 }
 
 // LoadFromPath attempts to load a config from the given file path. If the file

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -36,6 +37,10 @@ type ServerConfig struct {
 	KubeConfigs        map[string]*api.Config     `json:"kubeConfigs"`
 	ProxyURL           string                     `json:"proxyUrl"`
 	HTTPTimeoutSeconds int                        `json:"httpTimeoutSeconds"`
+}
+
+func (c *ServerConfig) GetHTTPTimeout() time.Duration {
+	return time.Duration(c.HTTPTimeoutSeconds) * time.Second
 }
 
 // LoadFromPath attempts to load a config from the given file path. If the file


### PR DESCRIPTION
Ref: https://github.com/rancher/rancher/issues/48321

Dedicated http clients in login and ssh commands that downloads certs and an ssh key respectively currently don't respect proxy settings and don't set http timeout.

This PR fixes that and makes use of Norman's API Client Timeout and ProxyURL options and makes it possible to specify those in the server config.