### PR TITLE
Update README.md docker image usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Run `CROSS=1 make build`.
 
 ## Docker Image
 
-Run `docker run --rm -it -v <PATH_TO_CONFIG>:/root/.rancher/cli2.json rancher/cli2 [ARGS]`.
+Run `docker run --rm -it -v <PATH_TO_CONFIG>:/home/cli/.rancher/cli2.json rancher/cli2 [ARGS]`.
 Pass credentials by replacing `<PATH_TO_CONFIG>` with your config file for the server.
 
 To build `rancher/cli`, run `make`.  To use a custom Docker repository, do `REPO=custom make`, which produces a `custom/cli` image.


### PR DESCRIPTION
PR updates the docker image in the README.md usage to match the [Dockerfile](./Dockerfile) user home directory.

Following the README
```bash
 % docker run --rm -it -v ./test.json:/root/.rancher/cli2.json rancher/cli2 catalog
FATA[0000] no configuration found, run `login`
```
Using the correct home dir cli image connects.
```bash
% docker run --rm -it -v ./test.json:/home/cli/.rancher/cli2.json rancher/cli2 catalog
FATA[0002] Get "https://192.168.1.216.sslip.io/v3": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

This addresses https://github.com/rancher/rancher/issues/48152
