### PR TITLE
Bump Go to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rancher/cli
 
 go 1.23.0
 
-toolchain go1.23.1
+toolchain go1.23.5
 
 replace k8s.io/client-go => k8s.io/client-go v0.31.1
 


### PR DESCRIPTION
The new BCI golang stable image registry.suse.com/bci/golang:1.23 is now available.
```sh
docker pull registry.suse.com/bci/golang:1.23
docker inspect registry.suse.com/bci/golang:1.23 | grep GOLANG_VERSION
                "GOLANG_VERSION=1.23.5",
```
Update the Go toolchain to 1.23.5 to match the new BCI image.

