### PR TITLE
Bump Go toolchain to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rancher/cli
 
-go 1.23.0
+go 1.23.4
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 replace k8s.io/client-go => k8s.io/client-go v0.31.1
 


### PR DESCRIPTION
Match bci:golang image and rancher/rancher.