### PR TITLE
[v2.8] Bump rancher/rancher to v2.8.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/norman v0.2.0
-	github.com/rancher/rancher/pkg/apis v0.0.0-20250325203928-5edcfa885eda
-	github.com/rancher/rancher/pkg/client v0.0.0-20250325203928-5edcfa885eda
+	github.com/rancher/rancher/pkg/apis v0.0.0-20250331170445-d704a664ad62
+	github.com/rancher/rancher/pkg/client v0.0.0-20250331170445-d704a664ad62
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -111,10 +111,10 @@ github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa h1:eRhvQJjIpPxJunlS3
 github.com/rancher/lasso v0.0.0-20240123150939-7055397d6dfa/go.mod h1:utdskbIL7kdVvPCUFPEJQDWJwPHGFpUCRfVkX2G2Xxg=
 github.com/rancher/norman v0.2.0 h1:PFIiHel0i0OFNZoygIS4oxJV6gRi1tffudzCqDnKLlA=
 github.com/rancher/norman v0.2.0/go.mod h1:WbNpu/HwChwKk54W0rWBdioxYVVZwVVz//UX84m/NvY=
-github.com/rancher/rancher/pkg/apis v0.0.0-20250325203928-5edcfa885eda h1:o42DKth3uyiQF1jDzgCnCABU/+I2vWu7f/rvS8oXStU=
-github.com/rancher/rancher/pkg/apis v0.0.0-20250325203928-5edcfa885eda/go.mod h1:KsweP8b8wqois/Pke9C2aw/ExIXBdqFg1/UUE0Gl5g8=
-github.com/rancher/rancher/pkg/client v0.0.0-20250325203928-5edcfa885eda h1:j5Xx8mRNkKc6DGCSEaPaUX6T2w4JVDxHzXmCg++mq1s=
-github.com/rancher/rancher/pkg/client v0.0.0-20250325203928-5edcfa885eda/go.mod h1:5dUb1jWFgDD6ySYxsMxRJ/+DLLmaCeUwTEkSMXe4h0E=
+github.com/rancher/rancher/pkg/apis v0.0.0-20250331170445-d704a664ad62 h1:/C4ILJdLCfqEsomFOvS8NmgoDvE2BDfbWw6YwpU+XPU=
+github.com/rancher/rancher/pkg/apis v0.0.0-20250331170445-d704a664ad62/go.mod h1:KsweP8b8wqois/Pke9C2aw/ExIXBdqFg1/UUE0Gl5g8=
+github.com/rancher/rancher/pkg/client v0.0.0-20250331170445-d704a664ad62 h1:fzfBWS0tJZ7jpyVfTsIz7ejvUye+5cZEuNNn8veeCX4=
+github.com/rancher/rancher/pkg/client v0.0.0-20250331170445-d704a664ad62/go.mod h1:5dUb1jWFgDD6ySYxsMxRJ/+DLLmaCeUwTEkSMXe4h0E=
 github.com/rancher/rke v1.5.15 h1:tAwa+1q8tK8/ZBmdfKFIGH40XD3xFQTR/vxTLCK9xxY=
 github.com/rancher/rke v1.5.15/go.mod h1:/z9oyKqYpFwgRBV9rfLxqUdjydz/VMCTcjld4uUt7uM=
 github.com/rancher/wrangler/v2 v2.1.4 h1:ohov0i6A9dJHHO6sjfsH4Dqv93ZTdm5lIJVJdPzVdQc=


### PR DESCRIPTION
```
git remote -v | grep upstream
upstream	git@github.com:rancher/rancher.git (fetch)
upstream	git@github.com:rancher/rancher.git (push)

git ls-remote upstream v2.8.14
d704a664ad62446de65e482ab712ae6b07f1b6e0	refs/tags/v2.8.14
```