### PR TITLE
feat: support platform linux/arm64

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 declare -A OS_ARCH_ARG
 
 OS_PLATFORM_ARG=(linux windows darwin)
-OS_ARCH_ARG[linux]="amd64 arm s390x"
+OS_ARCH_ARG[linux]="amd64 arm arm64 s390x"
 OS_ARCH_ARG[windows]="386 amd64"
 OS_ARCH_ARG[darwin]="amd64 arm64"
 


### PR DESCRIPTION
Using Docker (colima) on modern Apple Hardware runs container on linux/arm64. 

When did I stumble upon this? 
We use Container Images to "wrap" all necessary tools to interact with our rancher clusters. To build and install those images we use `mise`  (https://mise.jdx.dev) which resolves the correct dependency to download for us. Which is platform linux/arm64 that results in a `mise ERROR unsupported env: linux/arm64` cause there is no artefact for that platform provided. 

