### PR TITLE
[v2.10] Fix build script and harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
@@ -13,6 +20,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -39,6 +48,7 @@ jobs:
       run: ./scripts/build
 
     - name: Package
+      id: package
       run: |
         ./scripts/package
         ls -lR dist/artifacts
@@ -48,11 +58,11 @@ jobs:
         # Export the tag for the next step
         source ./scripts/version
         echo "VERSION=$VERSION"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Docker Build
       uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         push: false
         context: package
-        tags: rancher/cli2:${{ env.VERSION }}
+        tags: rancher/cli2:${{ steps.package.outputs.VERSION }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
       - name: Load Secrets from Vault
         uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      with:
+        persist-credentials: false
 
     - name: Load Secrets from Vault
       uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
@@ -60,6 +62,7 @@ jobs:
       run: ./scripts/build
 
     - name: Package
+      id: package
       run: |
         ./scripts/package
         ls -lR dist/artifacts
@@ -69,23 +72,24 @@ jobs:
         # Export the tag for the next step
         source ./scripts/version
         echo "VERSION=$VERSION"
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Upload Release assets
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.package.outputs.VERSION }}
       run: |
-        cd dist/artifacts/$VERSION
+        cd dist/artifacts/"$VERSION"
         ls -lR
         # generate sha256sum file
         find . -maxdepth 1 -type f ! -name sha256sum.txt -printf '%P\0' | xargs -0 sha256sum > sha256sum.txt
-        gh release upload $VERSION *.txt *.xz *.gz *.zip
+        gh release upload "$VERSION" *.txt *.xz *.gz *.zip
 
     - name: Upload Release assets to Google Cloud
       uses: google-github-actions/upload-cloud-storage@c0f6160ff80057923ff50e5e567695cea181ec23 # v2
       with:
-        path: dist/artifacts/${{ env.VERSION }}
-        destination: releases.rancher.com/cli2/${{ env.VERSION }}
+        path: dist/artifacts/${{ steps.package.outputs.VERSION }}
+        destination: releases.rancher.com/cli2/${{ steps.package.outputs.VERSION }}
         glob: '*.*' # copy only the files in the path folder
         parent: false
         process_gcloudignore: false
@@ -97,4 +101,4 @@ jobs:
       with:
         push: true
         context: package
-        tags: rancher/cli2:${{ env.VERSION }}
+        tags: rancher/cli2:${{ steps.package.outputs.VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.idea
 trash.lock
 /cli
+rancher

--- a/scripts/build
+++ b/scripts/build
@@ -4,28 +4,28 @@ source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
-declare -A OS_ARCH_ARG
-
-OS_PLATFORM_ARG=(linux windows darwin)
-OS_ARCH_ARG[linux]="amd64 arm arm64 s390x"
-OS_ARCH_ARG[windows]="386 amd64"
-OS_ARCH_ARG[darwin]="amd64 arm64"
-
-CGO_ENABLED=0 go build -ldflags="-w -s -X main.VERSION=$VERSION -extldflags -static" -o bin/rancher
+LDFLAGS="-w -s -X main.VERSION=$VERSION"
+if [ "$(uname -s)" = "Linux" ]; then
+    LDFLAGS="$LDFLAGS -extldflags -static"
+fi
+CGO_ENABLED=0 go build -ldflags="$LDFLAGS" -o bin/rancher
 
 if [ -n "$CROSS" ]; then
     rm -rf build/bin
     mkdir -p build/bin
-    for OS in ${OS_PLATFORM_ARG[@]}; do
-        for ARCH in ${OS_ARCH_ARG[${OS}]}; do
-            OUTPUT_BIN="build/bin/rancher_$OS-$ARCH"
-            if test "$OS" = "windows"; then
-                OUTPUT_BIN="${OUTPUT_BIN}.exe"
-            fi
-            echo "Building binary for $OS/$ARCH..."
-            GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build \
-                  -ldflags="-w -X main.VERSION=$VERSION" \
-                  -o ${OUTPUT_BIN} ./
-        done
+    for OS_ARCH in \
+        linux/amd64 linux/arm linux/arm64 linux/s390x \
+        windows/386 windows/amd64 \
+        darwin/amd64 darwin/arm64; do
+        OS="${OS_ARCH%/*}"
+        ARCH="${OS_ARCH#*/}"
+        OUTPUT_BIN="build/bin/rancher_$OS-$ARCH"
+        if test "$OS" = "windows"; then
+            OUTPUT_BIN="${OUTPUT_BIN}.exe"
+        fi
+        echo "Building binary for $OS/$ARCH..."
+        GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 go build \
+              -ldflags="-w -X main.VERSION=$VERSION" \
+              -o ${OUTPUT_BIN} ./
     done
 fi


### PR DESCRIPTION
Backport of #580

* Make build script work on MacOS
* Gitignore rancher binary everywhere
* Harden GitHub Actions workflows
    - Set persist-credentials: false on all checkout steps
    - Restrict permissions to contents: read in ci.yml
    - Add concurrency group to ci.yml to cancel redundant runs
    - Switch VERSION step output from  to
    - Quote  in release.yml shell commands