### PR TITLE
Fixes and Tweak for AzureAD OAuth

### DIFF
--- a/cmd/kubectl_token_oauth.go
+++ b/cmd/kubectl_token_oauth.go
@@ -52,7 +52,7 @@ func oauthAuth(client *http.Client, input *LoginInput, provider TypedProvider, u
 func getCallbackPort() (int, error) {
 	env := os.Getenv("CATTLE_OAUTH_CALLBACK_PORT")
 	if env == "" {
-		return 0, nil // Use random port
+		return 8888, nil // Default port
 	}
 
 	port, err := strconv.Atoi(env)

--- a/cmd/kubectl_token_oauth.go
+++ b/cmd/kubectl_token_oauth.go
@@ -52,7 +52,7 @@ func oauthAuth(client *http.Client, input *LoginInput, provider TypedProvider, u
 func getCallbackPort() (int, error) {
 	env := os.Getenv("CATTLE_OAUTH_CALLBACK_PORT")
 	if env == "" {
-		return 8888, nil // Default port
+		return 0, nil // Use random port
 	}
 
 	port, err := strconv.Atoi(env)

--- a/cmd/kubectl_token_oauth.go
+++ b/cmd/kubectl_token_oauth.go
@@ -199,8 +199,10 @@ func openBrowser(openURL string) error {
 		cmd = "xdg-open"
 		args = []string{openURL}
 	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start", "", openURL}
+		// rundll32 handles the URL as a single argument; avoids cmd.exe
+		// interpreting `&` in query strings as a command separator.
+		cmd = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", openURL}
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}


### PR DESCRIPTION
- On Windows, the authorization URL was being split by & and failing - changed to use a method which works with URLs with &
- ~~The default port was set to be random, which I think should be instead set to a static port so the default configuration has a static callback URL which can be configured~~ Azure AD works with random ports, this change has been reverted