### PR TITLE
Open the OAuth authorize URL on Windows without a shell

### DIFF
--- a/cmd/kubectl_token_oauth.go
+++ b/cmd/kubectl_token_oauth.go
@@ -12,9 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -186,25 +184,13 @@ func openBrowser(openURL string) error {
 		return fmt.Errorf("unsupported URL scheme %s", URL.Scheme)
 	}
 
-	var (
-		cmd  string
-		args []string
-	)
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = "open"
-		args = []string{openURL}
-	case "linux":
-		cmd = "xdg-open"
-		args = []string{openURL}
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start", "", openURL}
-	default:
-		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
-	}
-
-	return exec.Command(cmd, args...).Start()
+	// The launch is delegated to an OS-specific opener
+	// (kubectl_token_oauth_windows.go / kubectl_token_oauth_other.go). The URL
+	// is never handed to a shell: non-Windows passes it as a single argv
+	// element, Windows uses the ShellExecute API — so a server-supplied
+	// authorize URL (which legitimately contains `&` between query parameters)
+	// cannot be truncated or have its metacharacters interpreted.
+	return osOpenURL(openURL)
 }
 
 // callbackResult is used to communicate the result of the OAuth callback handling back to the main authentication flow.

--- a/cmd/kubectl_token_oauth_other.go
+++ b/cmd/kubectl_token_oauth_other.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// osOpenURL launches the platform's default URL handler with openURL as a
+// single argv element (no shell), so a server-supplied authorize URL cannot
+// inject shell metacharacters. openBrowser has already validated the scheme.
+func osOpenURL(openURL string) error {
+	var cmd string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	case "linux":
+		cmd = "xdg-open"
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+	return exec.Command(cmd, openURL).Start()
+}

--- a/cmd/kubectl_token_oauth_windows.go
+++ b/cmd/kubectl_token_oauth_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package cmd
+
+import "golang.org/x/sys/windows"
+
+// shellExecute is windows.ShellExecute, indirected so a test can capture the
+// arguments — proving the URL is passed opaquely with no command line — without
+// actually launching a browser.
+var shellExecute = windows.ShellExecute
+
+// osOpenURL opens openURL through the Windows ShellExecute API. ShellExecute
+// takes the target as a string argument to the shell API: it builds no command
+// line and spawns no cmd.exe, so a server-supplied authorize URL (which
+// legitimately contains `&` between query parameters) cannot be truncated or
+// have its metacharacters interpreted the way `cmd /c start` did. openBrowser
+// has already validated the scheme.
+func osOpenURL(openURL string) error {
+	verb, err := windows.UTF16PtrFromString("open")
+	if err != nil {
+		return err
+	}
+	target, err := windows.UTF16PtrFromString(openURL)
+	if err != nil {
+		return err
+	}
+	return shellExecute(0, verb, target, nil, nil, windows.SW_SHOWNORMAL)
+}

--- a/cmd/kubectl_token_oauth_windows_test.go
+++ b/cmd/kubectl_token_oauth_windows_test.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package cmd
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestOSOpenURLDoesNotShellInterpret guards the fix for AADSTS900144: it stubs
+// the ShellExecute call and asserts osOpenURL hands the URL to the API
+// opaquely — the full URL, metacharacters and all, as the target, with no
+// command-line arguments — so there is no shell for a server-supplied
+// authorize URL to be truncated by. The old `cmd /c start "" <url>` path built
+// a command line that cmd.exe parsed, dropping everything after the first
+// `&` (e.g. the OAuth `scope` parameter); this proves the current path does
+// not.
+func TestOSOpenURLDoesNotShellInterpret(t *testing.T) {
+	const u = `https://host/authorize?client_id=x&scope=y&echo pwned> C:\Temp\pwned.txt`
+
+	var gotVerb, gotFile, gotArgs *uint16
+	orig := shellExecute
+	shellExecute = func(_ windows.Handle, verb, file, args, _ *uint16, _ int32) error {
+		gotVerb, gotFile, gotArgs = verb, file, args
+		return nil
+	}
+	t.Cleanup(func() { shellExecute = orig })
+
+	if err := osOpenURL(u); err != nil {
+		t.Fatalf("osOpenURL: %v", err)
+	}
+	if got := windows.UTF16PtrToString(gotFile); got != u {
+		t.Fatalf("URL not passed opaquely:\n got  %q\n want %q", got, u)
+	}
+	if gotArgs != nil {
+		t.Fatalf("ShellExecute got command arguments %q — must be nil (no command line, no shell)",
+			windows.UTF16PtrToString(gotArgs))
+	}
+	if v := windows.UTF16PtrToString(gotVerb); v != "open" {
+		t.Fatalf("verb = %q, want \"open\"", v)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
 	k8s.io/client-go v12.0.0+incompatible
@@ -68,7 +69,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56914

## Problem

On Windows, openBrowser launched the browser via `cmd /c start "" <url>`. cmd.exe parses `&` as a command separator, so authorize URLs with multiple query parameters (e.g. Azure AD's client_id, scope, response_type) were truncated before reaching the browser, causing AADSTS900144 failures.

## Solution

`openBrowser` now delegates OS-specific launching to a new `osOpenURL` function. The Windows implementation uses the `ShellExecute` API, passing the URL as an opaque argument with no command line built, so it can't be reinterpreted by a shell. macOS and Linux keep using `exec.Command` with the URL as a single `argv` element, unchanged in behavior.